### PR TITLE
[WIP] Remove Parser Backtracking

### DIFF
--- a/Sources/Crust/Parser.swift
+++ b/Sources/Crust/Parser.swift
@@ -449,7 +449,7 @@ extension Parser {
       return try self.parseTypedParameterArrowExpr()
     }
 
-    //FIXME: re-enable: return try self.parseBasicExprListArrowExprSyntax()
+    //FIXME: re-enable: return try self.parseBasicExprListArrowExpr()
 
     switch peek() {
     case .forwardSlash:
@@ -494,13 +494,8 @@ extension Parser {
     )
   }
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-  func parseBasicExprListArrowExpr() throws -> BasicExprListArrowExprSyntax {
-=======
-  func parseBasicExprListArrowExprSyntax() throws
+  func parseBasicExprListArrowExpr() throws
     -> BasicExprListArrowExprSyntax {
->>>>>>> Begin removing backtracking from parser and adding diagnostics
     let exprList = try parseBasicExprList()
     let arrow = try consume(.arrow)
     let outputExpr = try parseExpr()
@@ -511,8 +506,6 @@ extension Parser {
     )
   }
 
-=======
->>>>>>> Got parser building again and improved handling of implicit tokens in diagnostics.
   func parseLambdaExpr() throws -> LambdaExprSyntax {
     let slashTok = try consume(.forwardSlash)
     let bindingList = try parseBindingList()

--- a/Sources/Crust/Shine.swift
+++ b/Sources/Crust/Shine.swift
@@ -122,7 +122,7 @@ fileprivate extension TokenSyntax {
 public func layout(_ ts: [TokenSyntax]) -> [TokenSyntax] {
   var toks = ts
   if toks.isEmpty {
-    toks.append(TokenSyntax(.eof))
+    toks.append(TokenSyntax(.eof, presence: .implicit))
   }
 
   var stainlessToks = [TokenSyntax]()

--- a/Sources/Drill/Invocation.swift
+++ b/Sources/Drill/Invocation.swift
@@ -57,8 +57,10 @@ public struct Invocation {
         }
       case .dump(.parse):
         let layoutTokens = layout(tokens)
-        let parser = Parser(tokens: layoutTokens)
-        SyntaxDumper(stream: &stderrStream).dump(parser.parseTopLevelModule()!)
+        let parser = Parser(diagnosticEngine: engine, tokens: layoutTokens)
+        if let module = parser.parseTopLevelModule() {
+          SyntaxDumper(stream: &stderrStream).dump(module)
+        }
       }
     }
   }

--- a/Sources/Lithosphere/Diagnostic.swift
+++ b/Sources/Lithosphere/Diagnostic.swift
@@ -29,7 +29,7 @@ public struct Diagnostic {
   /// Represents a diagnostic message. Clients should extend this struct with
   /// static constants or functions to enable leading-dot-style references to
   /// diagnostic messages.
-  public struct Message {
+  public struct Message: Error {
     /// The severity of the message, expressing how the compiler treats it.
     public enum Severity {
       /// The message is a warning that will not prevent compilation but that

--- a/Sources/Lithosphere/DiagnosticEngine.swift
+++ b/Sources/Lithosphere/DiagnosticEngine.swift
@@ -37,8 +37,10 @@ public final class DiagnosticEngine {
   ///           diagnostic is meant to apply to the entire compilation.
   ///   - actions: A closure to execute to incrementally add highlights and
   ///              notes to a Syntax node.
-  public func diagnose(_ message: Diagnostic.Message, node: Syntax? = nil,
-                       actions: Diagnostic.BuildActions? = nil) {
+  @discardableResult
+  public func diagnose(
+    _ message: Diagnostic.Message, node: Syntax? = nil,
+    actions: Diagnostic.BuildActions? = nil) -> Diagnostic.Message {
     let diagnostic = Diagnostic(message: message,
                                 node: node,
                                 actions: actions)
@@ -46,5 +48,6 @@ public final class DiagnosticEngine {
     for consumer in consumers {
       consumer.handle(diagnostic)
     }
+    return message
   }
 }

--- a/Sources/Lithosphere/Syntax.swift
+++ b/Sources/Lithosphere/Syntax.swift
@@ -71,6 +71,11 @@ public class Syntax {
     return raw.presence == .missing
   }
 
+  /// Whether or not this node it marked as `implicit`.
+  public var isImplicit: Bool {
+    return raw.presence == .implicit
+  }
+
   /// The parent of this syntax node, or `nil` if this node is the root.
   public var parent: Syntax? {
     guard let parentData = data.parent else { return nil }

--- a/Sources/Lithosphere/SyntaxKind.swift
+++ b/Sources/Lithosphere/SyntaxKind.swift
@@ -42,7 +42,6 @@ public enum SyntaxKind {
   case letExpr
   case applicationExpr
   case basicExpr
-  case applicationExprList
   case bindingList
   case binding
   case namedBinding
@@ -144,8 +143,6 @@ extension Syntax {
       return ApplicationExprSyntax(root: root, data: data)
     case .basicExpr:
       return BasicExprSyntax(root: root, data: data)
-    case .applicationExprList:
-      return ApplicationExprListSyntax(root: root, data: data)
     case .bindingList:
       return BindingListSyntax(root: root, data: data)
     case .binding:

--- a/Sources/Lithosphere/SyntaxNodes.swift
+++ b/Sources/Lithosphere/SyntaxNodes.swift
@@ -1225,17 +1225,17 @@ public class ApplicationExprSyntax: ExprSyntax {
     case exprs
   }
 
-  public convenience init(exprs: ApplicationExprListSyntax) {
+  public convenience init(exprs: BasicExprListSyntax) {
     let raw = RawSyntax.node(.applicationExpr, [
       exprs.raw,
     ], .present)
     let data = SyntaxData(raw: raw, indexInParent: 0, parent: nil)
     self.init(root: data, data: data)
   }
-  public var exprs: ApplicationExprListSyntax {
-    return child(at: Cursor.exprs) as! ApplicationExprListSyntax
+  public var exprs: BasicExprListSyntax {
+    return child(at: Cursor.exprs) as! BasicExprListSyntax
   }
-  public func withExprs(_ syntax: ApplicationExprListSyntax) -> ApplicationExprSyntax {
+  public func withExprs(_ syntax: BasicExprListSyntax) -> ApplicationExprSyntax {
     let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.exprs)
     return ApplicationExprSyntax(root: newRoot, data: newData)
   }
@@ -1249,15 +1249,6 @@ public class BasicExprSyntax: ExprSyntax {
     ], .present)
     let data = SyntaxData(raw: raw, indexInParent: 0, parent: nil)
     self.init(root: data, data: data)
-  }
-}
-
-public final class ApplicationExprListSyntax: SyntaxCollection<BasicExprSyntax> {
-  internal override init(root: SyntaxData, data: SyntaxData) {
-    super.init(root: root, data: data)
-  }
-  public init(elements: [BasicExprSyntax]) {
-    super.init(kind: .applicationExprList, elements: elements)
   }
 }
 

--- a/Sources/SyntaxGen/SyntaxNodes.swift
+++ b/Sources/SyntaxGen/SyntaxNodes.swift
@@ -257,14 +257,12 @@ let syntaxNodes = [
   ]),
 
   Node("ApplicationExpr", kind: "Expr", children: [
-    Child("exprs", kind: "ApplicationExprList")
+    Child("exprs", kind: "BasicExprList")
   ]),
 
   Node("BasicExpr", kind: "Expr", children: []),
 
   // application ::= <basic-expr> <application>
-
-  Node("ApplicationExprList", element: "BasicExpr"),
 
   // binding-list ::= <qualified-name>
   //                | <typed-parameter>

--- a/Tests/SyntaxTests/SyntaxTestRunner.swift
+++ b/Tests/SyntaxTests/SyntaxTestRunner.swift
@@ -21,6 +21,50 @@ enum Action {
 }
 
 class SyntaxTestRunner: XCTestCase {
+  var engine: DiagnosticEngine!
+
+  /// A diagnostic consumer that emits an XCTFail with the serialized
+  /// diagnostic whenever a diagnostic is emitted.
+  class XCTestFailureConsumer: DiagnosticConsumer {
+    /// A reference type that exists to keep alive a String.
+    class StreamBuffer: TextOutputStream {
+      var value = ""
+      func write(_ string: String) {
+        value += string
+      }
+      func clear() {
+        value = ""
+      }
+    }
+
+    /// A buffer for each diagnostic.
+    var scratch = StreamBuffer()
+
+    /// A printing diagnostic consumer that will serialize diagnostics
+    /// to a string.
+    let printer: PrintingDiagnosticConsumer<StreamBuffer>
+
+    init() {
+      printer = .init(stream: &scratch)
+    }
+
+    /// XCTFails with the serialized version of the diagnostic provided.
+    func handle(_ diagnostic: Diagnostic) {
+      scratch.clear()
+      printer.handle(diagnostic)
+      XCTFail(scratch.value)
+    }
+
+    func finalize() {
+      // Do nothing
+    }
+  }
+
+  override func setUp() {
+    engine = DiagnosticEngine()
+    engine.register(XCTestFailureConsumer())
+  }
+
   func testSyntax() {
     let filesURL = URL(fileURLWithPath: #file)
       .deletingLastPathComponent()
@@ -89,7 +133,7 @@ class SyntaxTestRunner: XCTestCase {
     case .describingTokens:
       TokenDescriber.describe(tokens, to: &stdoutStream)
     case .dumpingParse:
-      let parser = Parser(tokens: layoutTokens)
+      let parser = Parser(diagnosticEngine: engine, tokens: layoutTokens)
       guard let tlm = parser.parseTopLevelModule() else {
         XCTFail("Parsing top level module failed!")
         return


### PR DESCRIPTION
In order to facilitate diagnostics and parser recovery, we need to remove backtracking from the parser entirely. Instead, lookahead to disambiguate, and try to avoid terms that require infinite lookahead to disambiguate.