### PR TITLE
Adding swiftlint steps to CI config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ matrix:
       sudo: required
       dist: trusty
       before_install:
+        - sudo apt-get update -qq
+        - sudo apt-get install -qq clang curl git libblocksruntime0 libcurl4-openssl-dev libedit2 libicu55 libkqueue0 libpython2.7-dev libxml2 python2.7 tzdata uuid-dev
         - git submodule update --init --recursive
         - wget -q -O - https://swift.org/keys/all-keys.asc | gpg --import -
         - wget https://swift.org/builds/swift-4.0-release/ubuntu1404/swift-4.0-RELEASE/swift-4.0-RELEASE-ubuntu14.04.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
       dist: trusty
       before_install:
         - sudo apt-get update -qq
-        - sudo apt-get install -qq clang curl git libblocksruntime0 libcurl4-openssl-dev libedit2 libicu55 libkqueue0 libpython2.7-dev libxml2 python2.7 tzdata uuid-dev
+        - sudo apt-get install -qq clang-3.5 curl git libblocksruntime0 libcurl4-openssl-dev libedit2 libicu52 libkqueue0 libpython2.7-dev libxml2 python2.7 uuid-dev
         - git submodule update --init --recursive
         - wget -q -O - https://swift.org/keys/all-keys.asc | gpg --import -
         - wget https://swift.org/builds/swift-4.0-release/ubuntu1404/swift-4.0-RELEASE/swift-4.0-RELEASE-ubuntu14.04.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,10 @@ matrix:
     - os: osx
       language: objective-c
       osx_image: xcode9
+      before_install:
+        - brew install swiftlint
       script:
+        - swiftlint
         - swift test
     - os: linux
       language: generic
@@ -17,5 +20,9 @@ matrix:
         - wget -q -O - https://swift.org/keys/all-keys.asc | gpg --import -
         - wget https://swift.org/builds/swift-4.0-release/ubuntu1404/swift-4.0-RELEASE/swift-4.0-RELEASE-ubuntu14.04.tar.gz
         - tar xzf swift-4.0-RELEASE-ubuntu14.04.tar.gz
+        - wget https://github.com/realm/SwiftLint/archive/0.23.1.tar.gz -O swiftlint.tar.gz
+        - tar xzf swiftlint.tar.gz
+        - cd SwiftLint-0.23.1 && ../swift-4.0-RELEASE-ubuntu14.04/usr/bin/swift build
       script:
+        - ${PWD}/SwiftLint-0.23.1/.build/debug/swiftlint
         - ${PWD}/swift-4.0-RELEASE-ubuntu14.04/usr/bin/swift test

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ matrix:
       script:
         - swiftlint
         - swift test
-        - brew install swiftlint
-        - swiftlint
     - os: linux
       language: generic
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
         - tar xzf swift-4.0-RELEASE-ubuntu14.04.tar.gz
         - wget https://github.com/realm/SwiftLint/archive/0.23.1.tar.gz -O swiftlint.tar.gz
         - tar xzf swiftlint.tar.gz
-        - cd SwiftLint-0.23.1 && ../swift-4.0-RELEASE-ubuntu14.04/usr/bin/swift build && cd ..
+        - cd SwiftLint-0.23.1 && ../swift-4.0-RELEASE-ubuntu14.04/usr/bin/swift build -c release && cd ..
       script:
-        - LINUX_SOURCEKIT_LIB_PATH=${PWD}/swift-4.0-RELEASE-ubuntu14.04/usr/lib ${PWD}/SwiftLint-0.23.1/.build/debug/swiftlint
+        - LINUX_SOURCEKIT_LIB_PATH=${PWD}/swift-4.0-RELEASE-ubuntu14.04/usr/lib ${PWD}/SwiftLint-0.23.1/.build/release/swiftlint
         - ${PWD}/swift-4.0-RELEASE-ubuntu14.04/usr/bin/swift test

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
         - tar xzf swift-4.0-RELEASE-ubuntu14.04.tar.gz
         - wget https://github.com/realm/SwiftLint/archive/0.23.1.tar.gz -O swiftlint.tar.gz
         - tar xzf swiftlint.tar.gz
-        - cd SwiftLint-0.23.1 && ../swift-4.0-RELEASE-ubuntu14.04/usr/bin/swift build
+        - cd SwiftLint-0.23.1 && ../swift-4.0-RELEASE-ubuntu14.04/usr/bin/swift build && cd ..
       script:
         - ${PWD}/SwiftLint-0.23.1/.build/debug/swiftlint
         - ${PWD}/swift-4.0-RELEASE-ubuntu14.04/usr/bin/swift test

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,5 @@ matrix:
         - tar xzf swiftlint.tar.gz
         - cd SwiftLint-0.23.1 && ../swift-4.0-RELEASE-ubuntu14.04/usr/bin/swift build && cd ..
       script:
-        - ${PWD}/SwiftLint-0.23.1/.build/debug/swiftlint
+        - LINUX_SOURCEKIT_LIB_PATH=${PWD}/swift-4.0-RELEASE-ubuntu14.04/usr/lib ${PWD}/SwiftLint-0.23.1/.build/debug/swiftlint
         - ${PWD}/swift-4.0-RELEASE-ubuntu14.04/usr/bin/swift test


### PR DESCRIPTION
Addresses #12 by adding a simple `swiftlint` step to both Linux and macOS builds. The linux side could use a little cleanup at this point. 🏚