### PR TITLE
Add Contributing guide and PR/Issue templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing to `silt`
+
+We appreciate contributions from people from all backgrounds and experience
+levels. Silt is an educational project for its owners, and we don't have all
+the answers about how things will work in the long term. Because of that, we
+want to encourage external contributors to use their contributions to learn
+the ins and outs of compiler development as well. You need not be a "compiler
+wizard" to contribute -- we certainly aren't!
+
+As such, we commit to treat contributors with respect, and always give
+constructive feedback. All contributors must hold themselves to the terms of
+the [Contributor's Covenant](CODE_OF_CONDUCT.md) to ensure a respectful
+environment.
+
+# Steps for Contributions
+
+- Look through the open issues for something you'd like to address. If what you
+  want to fix is not currently tracked in the issues, make a new issue
+  describing the problem and assign yourself.
+- Fork the repository to your GitHub account.
+- Make a new branch off of `master`
+  - `git checkout -b branch-name-here`
+  - Bonus points if your branch name is a pun based on your PR contents 👌
+    - Keep puns respectful -- see the covenant.
+- Implement your fix. If the fix is non-trivial, it might be a good idea to
+  start a work-in-progress pull request, especially if you want feedback on the
+  direction of your change. To do so, prepend your PR title with `[WIP]`.
+- Implement a test that ensures your fix is correct. The best way to do this
+  is to add a test that fails prior to implementing your change, and passes
+  once your change is implemented.
+- Make a PR (or remove `[WIP]`).
+  - Ensure you link to the issue you resolved by the PR in the description.
+  - Use the PR description to explain what your change does and why it fixes
+    the issue.
+- Add one of the code owners (@harlanhaskins or @codafi) as a reviewer.
+  - We'll have a review process where we look over the code, make sure it
+    seems correct, and discuss the contents of the PR.
+  - If conflicts arise, we recommend rebasing your changes on the upstream
+    master.
+- After a code review and discussion, CI will test your changes. Once the PR
+  is accepted, and CI passes, it'll be merged!

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,34 @@
+Version
+=======
+
+_Share the git commit hash of the build that you are using. You can find it by running `git rev-parse HEAD` in the framework directory._
+
+Environment
+===========
+
+_What's your environment? macOS, Linux, or something else?_
+
+Description
+===========
+
+_In your own words, briefly describe the issue._
+
+Steps To Reproduce
+==================
+
+_List the actions that will reproduce the issue._
+
+Expected Result
+===============
+
+_What was the expected result after running the steps above?_
+
+Actual Result
+=============
+
+_What was the actual result after running the steps above?_
+
+Additional Information
+======================
+
+_Please provide any additional information that helps debugging, e.g. log output, stack traces, error codes, etc._

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,34 +1,27 @@
-Version
-=======
+### Version
 
 _Share the git commit hash of the build that you are using. You can find it by running `git rev-parse HEAD` in the framework directory._
 
-Environment
-===========
+### Environment
 
 _What's your environment? macOS, Linux, or something else?_
 
-Description
-===========
+### Description
 
 _In your own words, briefly describe the issue._
 
-Steps To Reproduce
-==================
+### Steps To Reproduce
 
 _List the actions that will reproduce the issue._
 
-Expected Result
-===============
+### Expected Result
 
 _What was the expected result after running the steps above?_
 
-Actual Result
-=============
+### Actual Result
 
 _What was the actual result after running the steps above?_
 
-Additional Information
-======================
+### Additional Information
 
 _Please provide any additional information that helps debugging, e.g. log output, stack traces, error codes, etc._

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 ### Version
 
-_Share the git commit hash of the build that you are using. You can find it by running `git rev-parse HEAD` in the framework directory._
+_Share the git commit hash of the build that you are using. You can find it by running `git rev-parse HEAD` in the root of the repository._
 
 ### Environment
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+What's in this pull request?
+============================
+
+_Briefly describe the contents of this pull request.  What did you add, remove,
+change?_
+
+Why merge this pull request?
+============================
+
+_Give us a short description of why this is important.  For example, future
+plans, cleanup, motivations for additional features, etc._
+
+What's worth discussing about this pull request?
+================================================
+
+_Is there any part of this pull request that is especially important,
+controversial, or that you're unsure of?  We can totally help!_
+
+What downsides are there to merging this pull request?
+======================================================
+
+_If you answered the last question in the affirmative, do you wish to discuss
+alternative implementations or have any other overarching concerns?_
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,23 @@
-What's in this pull request?
-============================
+### What's in this pull request?
 
 _Briefly describe the contents of this pull request.  What did you add, remove,
 change?_
 
-Why merge this pull request?
-============================
+_If this resolves an issue, put the issue number here to link them together._
+
+Resolves: Issue #
+
+### Why merge this pull request?
 
 _Give us a short description of why this is important.  For example, future
 plans, cleanup, motivations for additional features, etc._
 
-What's worth discussing about this pull request?
-================================================
+### What's worth discussing about this pull request?
 
 _Is there any part of this pull request that is especially important,
 controversial, or that you're unsure of?  We can totally help!_
 
-What downsides are there to merging this pull request?
-======================================================
+### What downsides are there to merging this pull request?
 
 _If you answered the last question in the affirmative, do you wish to discuss
 alternative implementations or have any other overarching concerns?_

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ contribution, and we pledge to always treat contributors with the respect they
 deserve. We have adopted the Contributor Covenant as our code of conduct,
 which can be read in this repository.
 
+For more info, and steps for a successful contribution, see the
+[Contribution Guide](.github/CONTRIBUTING.md).
+
 # Authors
 
 Robert Widmann ([@CodaFi](https://github.com/codafi))


### PR DESCRIPTION
### What's in this pull request?

This PR adds a contributing guide that sets up the intended guidelines for issues and pull requests,
and adds templates to help make those better.

### Why merge this pull request?

The templates give us a solid foundation for people making contributions to the project and helps
ensure a smooth contribution process.

### What's worth discussing about this pull request?

It would be worth discussing the way the contributing guide is worded.

