### PR TITLE
Layout the Moho

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,13 +23,17 @@ let package = Package(
       dependencies: ["Lithosphere"]),
     .target(
       name: "Drill",
-      dependencies: ["Lithosphere", "Crust"]),
+      dependencies: ["Lithosphere", "Crust", "Moho"]),
     .target(
       name: "silt",
       dependencies: ["Drill", "CommandLine"]),
     .target(
       name: "SyntaxGen",
       dependencies: ["CommandLine"]),
+
+    .target(
+      name: "Moho",
+      dependencies: ["Lithosphere", "Crust"]),
 
     .testTarget(
       name: "SyntaxTests",

--- a/Sources/Drill/Invocation.swift
+++ b/Sources/Drill/Invocation.swift
@@ -6,9 +6,11 @@
 /// available in the repository.
 
 import Foundation
-import Lithosphere
 import Rainbow
+
+import Lithosphere
 import Crust
+import Moho
 
 extension Diagnostic.Message {
   static let noInputFiles = Diagnostic.Message(.error,
@@ -61,6 +63,13 @@ public struct Invocation {
         if let module = parser.parseTopLevelModule() {
           SyntaxDumper(stream: &stderrStream).dump(module)
         }
+        SyntaxDumper(stream: &stderrStream).dump(parser.parseTopLevelModule()!)
+      case .dump(.scopes):
+//        let layoutTokens = layout(tokens)
+//        let parser = Parser(tokens: layoutTokens)
+//        let module = parser.parseTopLevelModule()!
+//        let binder = NameBinding(topLevel: module, engine: engine)
+        break
       }
     }
   }

--- a/Sources/Drill/Options.swift
+++ b/Sources/Drill/Options.swift
@@ -25,6 +25,8 @@ public enum Mode {
     /// The compiler will lex, layout, then parse the source text and print the
     /// file from the token stream including implicit scope marking tokens.
     case shined
+
+    case scopes
   }
   case dump(DumpKind)
   case compile

--- a/Sources/Moho/Name.swift
+++ b/Sources/Moho/Name.swift
@@ -1,0 +1,105 @@
+/// Name.swift
+///
+/// Copyright 2017, The Silt Language Project.
+///
+/// This project is released under the MIT license, a copy of which is
+/// available in the repository.
+
+import Lithosphere
+
+/// A internalized representation of an unqualified name.
+public struct Name: Equatable, Comparable, Hashable, CustomStringConvertible {
+  let syntax: TokenSyntax
+  let string: String
+
+  /// Create a `Name` by extracting it from a `TokenSyntax` node.
+  public init(name: TokenSyntax) {
+    self.syntax = name
+    self.string = name.tokenKind.text
+  }
+
+  public static func == (l: Name, r: Name) -> Bool {
+    return l.string == r.string
+  }
+
+  public static func < (l: Name, r: Name) -> Bool {
+    return l.string < r.string
+  }
+
+  public var hashValue: Int {
+    return self.string.hashValue
+  }
+
+  public var description: String {
+    return self.string
+  }
+}
+
+/// A sequence of unqualified names forming a unique named scope under which
+/// declarations may be qualified.
+public struct QualifiedName: Equatable, Hashable, CustomStringConvertible {
+  let name: Name
+  let module: [Name]
+
+  /// Create a `QualifiedName` from a `QualifiedNameSyntax` node.
+  public init(ast: QualifiedNameSyntax) {
+    precondition(!ast.isEmpty)
+    var mods = [Name]()
+    self.name = Name(name: ast[ast.count-1].name)
+    guard ast.count != 1 else {
+      self.module = []
+      return
+    }
+
+    for i in (0..<ast.count-2).reversed() {
+      mods.append(Name(name: ast[i].name))
+    }
+    self.module = mods
+  }
+
+  /// Create a qualified name with no base module.
+  public init(name: Name) {
+    self.name = name
+    self.module = []
+  }
+
+  public init(cons name: Name, _ ns: QualifiedName) {
+    self.name = name
+    self.module = [ns.name] + ns.module
+  }
+
+  public init(cons name: Name, _ module: [Name]) {
+    self.name = name
+    self.module = module
+  }
+
+  public var node: TokenSyntax {
+    return self.name.syntax
+  }
+
+  public var hashValue: Int {
+    return self.module.reduce(self.name.hashValue) { (acc, x) in
+      return acc ^ x.hashValue
+    }
+  }
+
+  public static func == (l: QualifiedName, r: QualifiedName) -> Bool {
+    guard l.module.count == r.module.count else {
+      return false
+    }
+
+    return zip(l.module, r.module).reduce(l.name == r.name) { (acc, x) in
+      return acc && (x.0 == x.1)
+    }
+  }
+
+  public var description: String {
+    return self.module.reduce("") { (acc, x) in
+      return acc + x.description + "."
+      } + self.name.description
+  }
+
+  public var string: String {
+    return self.description
+  }
+}

--- a/Sources/Moho/NameBinding.swift
+++ b/Sources/Moho/NameBinding.swift
@@ -1,0 +1,321 @@
+/// NameBinding.swift
+///
+/// Copyright 2017, The Silt Language Project.
+///
+/// This project is released under the MIT license, a copy of which is
+/// available in the repository.
+
+import Crust
+import Lithosphere
+
+// MARK: Lookup
+
+// The number of parameters.
+typealias NumExplicitArguments = Int
+typealias NumImplicitArguments = Int
+
+/// Specific information about a name returned from Lookup.
+enum NameInfo {
+  /// The result was a definition, retrieves the number of implicit arguments.
+  case definition(NumImplicitArguments)
+  /// The result was a constructor, retrieves the number of implicit and
+  /// explicit arguments.
+  case constructor(NumImplicitArguments, NumExplicitArguments)
+  /// The result was a record projection, retrieves the number of implicit
+  /// arguments.
+  case projection(NumImplicitArguments)
+  /// The result was a module, returns its local names.
+  case module(LocalNames)
+}
+
+public class NameBinding {
+  var activeScope: Scope
+  let engine: DiagnosticEngine
+
+  public init(topLevel: ModuleDeclSyntax, engine: DiagnosticEngine) {
+    self.activeScope = Scope(QualifiedName(ast: topLevel.moduleIdentifier))
+    self.engine = engine
+  }
+}
+
+extension NameBinding {
+  /// Returns whether the given name appears bound in this scope.
+  func isBoundVariable(_ n: Name) -> Bool {
+    return self.activeScope.vars[n] != nil
+  }
+
+  /// Under a new scope, execute a function returning a result.
+  func underScope<T>(_ s: (Scope) throws -> T) rethrows -> T {
+    let oldScope = self.activeScope
+    let copyScope = Scope(self.activeScope)
+    let result = try s(copyScope)
+    self.activeScope = oldScope
+    return result
+  }
+
+  /// Traverses namespaces back-to-front looking for a match to the provided
+  /// predicate.  If no namespace is suitable, this function returns `.none`.
+  private func lookup<A>(in f: (NameSpace) -> A?) -> A? {
+    for ns in [self.activeScope.nameSpace] + self.activeScope.parentNameSpaces {
+      if let a = f(ns) {
+        return .some(a)
+      }
+    }
+    return .none
+  }
+
+  /// Looks up information about a locally-defined name.  If the name is in
+  /// scope, its fully-qualified name and information about that name is
+  /// returned.
+  func lookupLocalName(_ n: Name) -> (FullyQualifiedName, NameInfo)? {
+    return lookup(in: { ns in
+      return ns.localNames[n].map { x in
+        return (QualifiedName(cons: n, ns.module), x)
+      }
+    })
+  }
+
+  /// Looks up a name that has been opened into local scope, perhaps under
+  /// a different name.  If there is a match, its fully-qualified name and
+  /// information about that name is returned.
+  func lookupOpenedName(_ n: Name) throws -> (FullyQualifiedName, NameInfo)? {
+    guard let mbNames = self.activeScope.openedNames[n] else {
+      return .none
+    }
+
+    guard mbNames.count == 1 else {
+      engine.diagnose(.ambiguousName(n, mbNames))
+      return .none
+    }
+
+    let x = mbNames[0]
+    return self.lookupFullyQualifiedName(x).map { ni in (x, ni) }
+  }
+
+  /// Looks up a fully-qualified name that has been opened into this scope by
+  /// traversing imported modules.  Because the fully qualified name is known,
+  /// only information about that name is returned if lookup suceeds.
+  func lookupFullyQualifiedName(_ n: FullyQualifiedName) -> NameInfo? {
+    let m = n.module.first!
+    let ms = Array(n.module.dropFirst())
+    let qn = QualifiedName(cons: m, ms)
+    return self.activeScope.importedModules[qn].flatMap { (_, exports) in
+      return exports[n.name]
+    }
+  }
+}
+
+// MARK: Name Resolution
+
+extension NameBinding {
+  struct Resolution<T> {
+    let qualifiedName: FullyQualifiedName
+    let info: T
+  }
+
+  /// Resolves a locally-defined name and returns a fully-qualified name and
+  /// information about that name.
+  ///
+  /// This function should be called if the name is known to be in scope.  It
+  /// throws an exception if not.
+  func resolveLocalName(_ n: Name) throws -> Resolution<NameInfo> {
+    guard let mb = self.lookupLocalName(n) else {
+      fatalError("\(n) is not in scope")
+    }
+    return Resolution(qualifiedName: mb.0, info: mb.1)
+  }
+
+  /// Resolves a locally-defined name that maps to a definition returns a
+  /// fully-qualified name and information about that definition.
+  ///
+  /// This function should be called if the name is known to be in scope and
+  /// that name resolves to a definition.  It throws an exception if not.
+  func resolveLocalDefinition(
+    _ n: Name) throws -> Resolution<NumImplicitArguments> {
+    let rln = try self.resolveLocalName(n)
+    guard case let .definition(hidden) = rln.info else {
+      fatalError("\(n) should be a definition")
+    }
+    return Resolution(qualifiedName: rln.qualifiedName, info: hidden)
+  }
+
+  /// Given the qualified name of a module, resolves it to a fully-qualified
+  /// name and returns information about the contents of the module.
+  func resolveModule(_ m: QualifiedName) throws -> Resolution<LocalNames> {
+    let lkup = try self.resolveQualifiedName(m)
+    switch lkup {
+    case let .some(.nameInfo(qn, .module(names))):
+      return Resolution(qualifiedName: qn, info: names)
+    case .none:
+      fatalError("\(m) is not in scope")
+    default:
+      fatalError("\(m) should be a module")
+    }
+  }
+
+  typealias ArgCount
+    = (implicit: NumImplicitArguments, explicit: NumExplicitArguments)
+
+  /// Given the qualified name of a constructor, resolves it to a
+  /// fully-qualified name and returns information about the constructor itself.
+  func resolveConstructor(_ m: QualifiedName) throws -> Resolution<ArgCount> {
+    let lkup = try self.resolveQualifiedName(m)
+    switch lkup {
+    case let .some(.nameInfo(qn, .constructor(hidden, args))):
+      return Resolution(qualifiedName: qn, info: (hidden, args))
+    case .none:
+      fatalError("\(m) is not in scope")
+    default:
+      fatalError("\(m) should be a constructor")
+    }
+  }
+
+  /// Given the qualified name of a module that has already been imported,
+  /// returns the fully-qualified name of the module and information about its
+  /// contents.
+  ///
+  /// If the named module is not in scope, or has not been previously imported,
+  /// this function throws an exception.  Be sure that `importModule` has been
+  /// called.
+  func resolveImportedModule(
+    _ n: QualifiedName) throws -> Resolution<LocalNames> {
+    let resolved = try self.resolveModule(n)
+    if self.activeScope.importedModules[resolved.qualifiedName] == nil {
+      fatalError("\(n) should be imported")
+    }
+    return resolved
+  }
+}
+
+extension NameBinding {
+  enum QualifiedLookupResult {
+    case variable(Name)
+    case nameInfo(FullyQualifiedName, NameInfo)
+  }
+
+  /// Looks up a qualified name and returns information about it.
+  private func resolveQualifiedName(
+    _ qn: QualifiedName) throws -> QualifiedLookupResult? {
+    let ms = Array(qn.module.dropFirst())
+    guard !ms.isEmpty else {
+      if self.isBoundVariable(qn.name) {
+        return .variable(qn.name)
+      } else {
+        switch self.lookupLocalName(qn.name) {
+        case let .some((qn, ni)):
+          return .nameInfo(qn, ni)
+        default:
+          let res = try self.lookupOpenedName(qn.name)
+          if let (qn, ni) = res {
+            return .nameInfo(qn, ni)
+          } else {
+            return .none
+          }
+        }
+      }
+    }
+
+    let res = try self.resolveImportedModule(QualifiedName(cons: qn.name, ms))
+    guard let ni = res.info[res.qualifiedName.name] else {
+      return .none
+    }
+    return .nameInfo(QualifiedName(cons: qn.name, res.qualifiedName), ni)
+  }
+}
+
+// MARK: Binding
+
+extension NameBinding {
+  /// Qualify a name with the module of the current active scope.
+  func qualify(name: Name) -> FullyQualifiedName {
+    return QualifiedName(cons: name, self.activeScope.nameSpace.module)
+  }
+
+  /// Bind a local definition in the current active scope.  Suitable for types,
+  /// constructors, and functions.
+  ///
+  /// FIXME: Break this up?
+  func bindDefinition(
+    named n: Name, _ hidden: NumImplicitArguments) -> FullyQualifiedName? {
+    return self.bindLocal(named: n, info: .definition(hidden))
+  }
+
+  /// Bind a record projection function in the current active scope.
+  func bindProjection(
+    named n: Name, _ hidden: NumImplicitArguments) -> FullyQualifiedName? {
+    return self.bindLocal(named: n, info: .projection(hidden))
+  }
+
+  /// Bind a local variable in the current active scope.
+  ///
+  /// This function checks if the variable name is not in a list of reserved
+  /// names.  If it is, the name is diagnosed.
+  func bindVariable(named n: Name) -> Name? {
+    guard checkNotReserved(n) else {
+      return nil
+    }
+
+    return self.activeScope.local { scope in
+      scope.vars[n] = n.syntax
+      return n
+    }
+  }
+
+  /// Binds a local variable and information about that variable in the current
+  /// active scope.
+  ///
+  /// This function checks if the variable name is reserved or previously
+  /// declared in some scope.  If either of these is the case, the name is
+  /// diagnosed.
+  func bindLocal(named n: Name, info ni: NameInfo) -> FullyQualifiedName? {
+    guard checkNotReserved(n) && checkNotShadowing(n) else {
+      return nil
+    }
+
+    return self.activeScope.local { scope in
+      scope.nameSpace.localNames[n] = ni
+      return self.qualify(name: n)
+    }
+  }
+
+  private func checkNotReserved(_ n: Name) -> Bool {
+    if Set(["Type"]).contains(n.string) {
+      engine.diagnose(.nameReserved(n))
+      return false
+    }
+    return true
+  }
+
+  private func checkNotShadowing(_ n: Name) -> Bool {
+    if self.activeScope.vars[n] != nil {
+      engine.diagnose(.nameShadows(n))
+      return false
+    }
+    if let (qn, _) = self.lookupLocalName(n) {
+      engine.diagnose(.nameShadows(n, local: qn))
+      return false
+    }
+    return true
+  }
+}
+
+// MARK: Action
+
+extension NameBinding {
+  /// Imports a module and binds information about its local names.
+  func importModule(
+    _ qn: QualifiedName,
+    _ hidden: NumImplicitArguments,
+    _ names: LocalNames) -> Bool {
+    switch self.activeScope.importedModules[qn] {
+    case .some(_):
+      engine.diagnose(.duplicateImport(qn))
+      return false
+    default:
+      return self.activeScope.local { scope in
+        scope.importedModules[qn] = (hidden, names)
+        return true
+      }
+    }
+  }
+}

--- a/Sources/Moho/Scope.swift
+++ b/Sources/Moho/Scope.swift
@@ -1,0 +1,63 @@
+/// Scope.swift
+///
+/// Copyright 2017, The Silt Language Project.
+///
+/// This project is released under the MIT license, a copy of which is
+/// available in the repository.
+
+import Lithosphere
+
+// Indicates that a name is fully qualified.
+typealias FullyQualifiedName = QualifiedName
+
+// A mapping of module-defined names to information about that name.
+typealias LocalNames = [Name: NameInfo]
+
+// A namespace is a fully-qualified named scope into which a number of unique
+// names may be placed.
+struct NameSpace {
+  var module: FullyQualifiedName
+  // The definitions defined in some module.
+  var localNames: LocalNames
+
+  init(_ qn: FullyQualifiedName) {
+    self.module = qn
+    self.localNames = [:]
+  }
+}
+
+// A scope under which local variables are opened and the contents of modules
+// are imported.
+final class Scope {
+  // The variables in scope.
+  var vars: [Name: TokenSyntax]
+  // The namespace for the current module.
+  var nameSpace: NameSpace
+  // The namespaces for the parent modules.
+  var parentNameSpaces: [NameSpace]
+  // Mapping from "opened" names to fully qualified names.  If the mapping
+  // contains multiple items then that name is ambiguous.
+  var openedNames: [Name: [FullyQualifiedName]]
+  // The imported modules.
+  var importedModules: [FullyQualifiedName: (NumImplicitArguments, LocalNames)]
+
+  init(_ n: FullyQualifiedName) {
+    self.vars = [:]
+    self.nameSpace = NameSpace(n)
+    self.parentNameSpaces = []
+    self.openedNames = [:]
+    self.importedModules = [:]
+  }
+
+  init(_ s: Scope) {
+    self.vars = s.vars
+    self.nameSpace = s.nameSpace
+    self.parentNameSpaces = s.parentNameSpaces
+    self.openedNames = s.openedNames
+    self.importedModules = s.importedModules
+  }
+
+  func local<T>(_ s: (Scope) throws -> T) rethrows -> T {
+    return try s(self)
+  }
+}

--- a/Sources/Moho/ScopeDiagnostics.swift
+++ b/Sources/Moho/ScopeDiagnostics.swift
@@ -1,0 +1,33 @@
+/// ScopeDiagnostics.swift
+///
+/// Copyright 2017, The Silt Language Project.
+///
+/// This project is released under the MIT license, a copy of which is
+/// available in the repository.
+
+import Lithosphere
+
+extension Diagnostic.Message {
+  static func ambiguousName(
+    _ n: Name, _ others: [FullyQualifiedName]) -> Diagnostic.Message {
+    return Diagnostic.Message(.error, "\(n) could be any of \(others)")
+  }
+
+  static func nameReserved(_ n: Name) -> Diagnostic.Message {
+    return Diagnostic.Message(.error, "cannot use reserved name \(n)")
+  }
+
+  static func nameShadows(_ n: Name) -> Diagnostic.Message {
+    return Diagnostic.Message(.error, "cannot shadow name \(n)")
+  }
+
+  static func nameShadows(
+    _ n: Name, local: FullyQualifiedName) -> Diagnostic.Message {
+    return Diagnostic.Message(.error,
+                              "cannot shadow qualified name \(local) with \(n)")
+  }
+
+  static func duplicateImport(_ qn: QualifiedName) -> Diagnostic.Message {
+    return Diagnostic.Message(.warning, "\(qn) already imported")
+  }
+}

--- a/Sources/Moho/Syntax.swift
+++ b/Sources/Moho/Syntax.swift
@@ -1,0 +1,117 @@
+/// Syntax.swift
+///
+/// Copyright 2017, The Silt Language Project.
+///
+/// This project is released under the MIT license, a copy of which is
+/// available in the repository.
+
+import Lithosphere
+
+public struct DeclaredModule {
+  let moduleName: QualifiedName
+  let params: [(Name, Expr)]
+  let namespace: [QualifiedName]
+  let decls: [Decl]
+}
+
+enum Decl {
+  case ascription(TypeSignature)
+  case postulate(TypeSignature)
+  case dataSignature(TypeSignature)
+  case recordSignature(TypeSignature)
+  case function(QualifiedName, [DeclaredClause])
+  case data(QualifiedName, [Name], [TypeSignature])
+  case record(QualifiedName, [Name], QualifiedName, [TypeSignature])
+  case module(DeclaredModule)
+  case importDecl(QualifiedName, [Expr])
+  case openImport(QualifiedName)
+}
+
+public struct TypeSignature {
+  let name: QualifiedName
+  let type: Expr
+}
+
+struct DeclaredClause {
+  let patterns: [DeclaredPattern]
+  let body: DeclaredClauseBody
+}
+
+enum DeclaredClauseBody {
+  case Empty
+  case Body(Expr, [Decl])
+}
+
+public indirect enum Expr: Equatable {
+  case lambda(Name, Expr)
+  case pi(Name, Expr, Expr)
+  case function(Expr, Expr)
+  case equal(Expr, Expr, Expr)
+  case apply(ApplyHead, [Elimination])
+  case constructor(QualifiedName, [Expr])
+  case type
+  case meta
+  case refl
+
+  public static func == (l: Expr, r: Expr) -> Bool {
+    switch (l, r) {
+    case let (.lambda(x, e), .lambda(y, f)):
+      return x == y && e == f
+    case let (.pi(x, a, b), .pi(y, c, d)):
+      return x == y && a == c && b == d
+    case let (.function(a, b), .function(c, d)):
+      return a == c && b == d
+    case let (.equal(a, x, y), .equal(b, z, w)):
+      return a == b && x == z && w == y
+    case let (.apply(h, es), .apply(g, fs)):
+      return h == g && es == fs
+    case (.type, .type):
+      return true
+    case (.meta, .meta):
+      return true
+    case (.refl, .refl):
+      return true
+    default:
+      return false
+    }
+  }
+}
+
+public enum ApplyHead: Equatable {
+  case variable(Name)
+  case definition(QualifiedName)
+
+  public static func == (l: ApplyHead, r: ApplyHead) -> Bool {
+    switch (l, r) {
+    case let (.variable(n), .variable(m)):
+      return n == m
+    case let (.definition(e), .definition(f)):
+      return e == f
+    default:
+      return false
+    }
+  }
+}
+
+public enum Elimination: Equatable {
+  case apply(Expr)
+  case projection(QualifiedName)
+
+  public static func == (l: Elimination, r: Elimination) -> Bool {
+    switch (l, r) {
+    case let (.apply(e), .apply(f)):
+      return e == f
+    case let (.projection(n), .projection(m)):
+      return n == m
+    default:
+      return false
+    }
+  }
+}
+
+public enum DeclaredPattern {
+  case variable(Name)
+  case wild(SourceLocation)
+  case constructor(QualifiedName, [DeclaredPattern])
+  case empty(SourceLocation)
+}


### PR DESCRIPTION
Along the Moho, we accept initially-parsed syntax in the form of
raw application expressions and declarations and re-parse them
into forms more amenable to semantic analysis, resolving and binding
names along the way.  The final target of the phase is a much simpler,
more reasonable AST that should point back into the original for
the final phase that emits user-relevant diagnostics: TypeChecking.

As I'm blocked on the parser changes to application going through, I'm going to submit this now without the re-parsing or name binding phase so I can keep moving on to semantic work.