### PR TITLE
Eliminate Backtracking in Parser

### DIFF
--- a/Sources/Crust/Parser.swift
+++ b/Sources/Crust/Parser.swift
@@ -449,7 +449,7 @@ extension Parser {
       return try self.parseTypedParameterArrowExpr()
     }
 
-    //FIXME: re-enable: return try self.parseBasicExprListArrowExprSyntax()
+    //FIXME: re-enable: return try self.parseBasicExprListArrowExpr()
 
     switch peek() {
     case .forwardSlash:
@@ -494,13 +494,8 @@ extension Parser {
     )
   }
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-  func parseBasicExprListArrowExpr() throws -> BasicExprListArrowExprSyntax {
-=======
-  func parseBasicExprListArrowExprSyntax() throws
+  func parseBasicExprListArrowExpr() throws
     -> BasicExprListArrowExprSyntax {
->>>>>>> Begin removing backtracking from parser and adding diagnostics
     let exprList = try parseBasicExprList()
     let arrow = try consume(.arrow)
     let outputExpr = try parseExpr()
@@ -511,8 +506,6 @@ extension Parser {
     )
   }
 
-=======
->>>>>>> Got parser building again and improved handling of implicit tokens in diagnostics.
   func parseLambdaExpr() throws -> LambdaExprSyntax {
     let slashTok = try consume(.forwardSlash)
     let bindingList = try parseBindingList()

--- a/Sources/Crust/Shine.swift
+++ b/Sources/Crust/Shine.swift
@@ -122,7 +122,7 @@ fileprivate extension TokenSyntax {
 public func layout(_ ts: [TokenSyntax]) -> [TokenSyntax] {
   var toks = ts
   if toks.isEmpty {
-    toks.append(TokenSyntax(.eof))
+    toks.append(TokenSyntax(.eof, presence: .implicit))
   }
 
   var stainlessToks = [TokenSyntax]()

--- a/Sources/Drill/Invocation.swift
+++ b/Sources/Drill/Invocation.swift
@@ -57,8 +57,10 @@ public struct Invocation {
         }
       case .dump(.parse):
         let layoutTokens = layout(tokens)
-        let parser = Parser(tokens: layoutTokens)
-        SyntaxDumper(stream: &stderrStream).dump(parser.parseTopLevelModule()!)
+        let parser = Parser(diagnosticEngine: engine, tokens: layoutTokens)
+        if let module = parser.parseTopLevelModule() {
+          SyntaxDumper(stream: &stderrStream).dump(module)
+        }
       }
     }
   }

--- a/Sources/Lithosphere/Diagnostic.swift
+++ b/Sources/Lithosphere/Diagnostic.swift
@@ -29,7 +29,7 @@ public struct Diagnostic {
   /// Represents a diagnostic message. Clients should extend this struct with
   /// static constants or functions to enable leading-dot-style references to
   /// diagnostic messages.
-  public struct Message {
+  public struct Message: Error {
     /// The severity of the message, expressing how the compiler treats it.
     public enum Severity {
       /// The message is a warning that will not prevent compilation but that

--- a/Sources/Lithosphere/DiagnosticEngine.swift
+++ b/Sources/Lithosphere/DiagnosticEngine.swift
@@ -37,8 +37,10 @@ public final class DiagnosticEngine {
   ///           diagnostic is meant to apply to the entire compilation.
   ///   - actions: A closure to execute to incrementally add highlights and
   ///              notes to a Syntax node.
-  public func diagnose(_ message: Diagnostic.Message, node: Syntax? = nil,
-                       actions: Diagnostic.BuildActions? = nil) {
+  @discardableResult
+  public func diagnose(
+    _ message: Diagnostic.Message, node: Syntax? = nil,
+    actions: Diagnostic.BuildActions? = nil) -> Diagnostic.Message {
     let diagnostic = Diagnostic(message: message,
                                 node: node,
                                 actions: actions)
@@ -46,5 +48,6 @@ public final class DiagnosticEngine {
     for consumer in consumers {
       consumer.handle(diagnostic)
     }
+    return message
   }
 }

--- a/Sources/Lithosphere/Syntax.swift
+++ b/Sources/Lithosphere/Syntax.swift
@@ -71,6 +71,11 @@ public class Syntax {
     return raw.presence == .missing
   }
 
+  /// Whether or not this node it marked as `implicit`.
+  public var isImplicit: Bool {
+    return raw.presence == .implicit
+  }
+
   /// The parent of this syntax node, or `nil` if this node is the root.
   public var parent: Syntax? {
     guard let parentData = data.parent else { return nil }

--- a/Sources/Lithosphere/SyntaxKind.swift
+++ b/Sources/Lithosphere/SyntaxKind.swift
@@ -42,7 +42,6 @@ public enum SyntaxKind {
   case letExpr
   case applicationExpr
   case basicExpr
-  case applicationExprList
   case bindingList
   case binding
   case namedBinding
@@ -144,8 +143,6 @@ extension Syntax {
       return ApplicationExprSyntax(root: root, data: data)
     case .basicExpr:
       return BasicExprSyntax(root: root, data: data)
-    case .applicationExprList:
-      return ApplicationExprListSyntax(root: root, data: data)
     case .bindingList:
       return BindingListSyntax(root: root, data: data)
     case .binding:

--- a/Sources/Lithosphere/SyntaxKind.swift
+++ b/Sources/Lithosphere/SyntaxKind.swift
@@ -30,13 +30,10 @@ public enum SyntaxKind {
   case recordFieldAssignmentList
   case recordFieldAssignment
   case functionDecl
-  case functionClauseList
-  case functionClause
-  case withRuleFunctionClause
-  case normalFunctionClause
-  case patternClauseList
+  case functionClauseDecl
+  case withRuleFunctionClauseDecl
+  case normalFunctionClauseDecl
   case typedParameterArrowExpr
-  case basicExprListArrowExpr
   case lambdaExpr
   case quantifiedExpr
   case letExpr
@@ -119,20 +116,14 @@ extension Syntax {
       return RecordFieldAssignmentSyntax(root: root, data: data)
     case .functionDecl:
       return FunctionDeclSyntax(root: root, data: data)
-    case .functionClauseList:
-      return FunctionClauseListSyntax(root: root, data: data)
-    case .functionClause:
-      return FunctionClauseSyntax(root: root, data: data)
-    case .withRuleFunctionClause:
-      return WithRuleFunctionClauseSyntax(root: root, data: data)
-    case .normalFunctionClause:
-      return NormalFunctionClauseSyntax(root: root, data: data)
-    case .patternClauseList:
-      return PatternClauseListSyntax(root: root, data: data)
+    case .functionClauseDecl:
+      return FunctionClauseDeclSyntax(root: root, data: data)
+    case .withRuleFunctionClauseDecl:
+      return WithRuleFunctionClauseDeclSyntax(root: root, data: data)
+    case .normalFunctionClauseDecl:
+      return NormalFunctionClauseDeclSyntax(root: root, data: data)
     case .typedParameterArrowExpr:
       return TypedParameterArrowExprSyntax(root: root, data: data)
-    case .basicExprListArrowExpr:
-      return BasicExprListArrowExprSyntax(root: root, data: data)
     case .lambdaExpr:
       return LambdaExprSyntax(root: root, data: data)
     case .quantifiedExpr:

--- a/Sources/Lithosphere/SyntaxNodes.swift
+++ b/Sources/Lithosphere/SyntaxNodes.swift
@@ -1225,17 +1225,17 @@ public class ApplicationExprSyntax: ExprSyntax {
     case exprs
   }
 
-  public convenience init(exprs: ApplicationExprListSyntax) {
+  public convenience init(exprs: BasicExprListSyntax) {
     let raw = RawSyntax.node(.applicationExpr, [
       exprs.raw,
     ], .present)
     let data = SyntaxData(raw: raw, indexInParent: 0, parent: nil)
     self.init(root: data, data: data)
   }
-  public var exprs: ApplicationExprListSyntax {
-    return child(at: Cursor.exprs) as! ApplicationExprListSyntax
+  public var exprs: BasicExprListSyntax {
+    return child(at: Cursor.exprs) as! BasicExprListSyntax
   }
-  public func withExprs(_ syntax: ApplicationExprListSyntax) -> ApplicationExprSyntax {
+  public func withExprs(_ syntax: BasicExprListSyntax) -> ApplicationExprSyntax {
     let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.exprs)
     return ApplicationExprSyntax(root: newRoot, data: newData)
   }
@@ -1249,15 +1249,6 @@ public class BasicExprSyntax: ExprSyntax {
     ], .present)
     let data = SyntaxData(raw: raw, indexInParent: 0, parent: nil)
     self.init(root: data, data: data)
-  }
-}
-
-public final class ApplicationExprListSyntax: SyntaxCollection<BasicExprSyntax> {
-  internal override init(root: SyntaxData, data: SyntaxData) {
-    super.init(root: root, data: data)
-  }
-  public init(elements: [BasicExprSyntax]) {
-    super.init(kind: .applicationExprList, elements: elements)
   }
 }
 

--- a/Sources/Lithosphere/SyntaxNodes.swift
+++ b/Sources/Lithosphere/SyntaxNodes.swift
@@ -759,15 +759,13 @@ public class RecordFieldAssignmentSyntax: Syntax {
 public class FunctionDeclSyntax: DeclSyntax {
   public enum Cursor: Int {
     case ascription
-    case ascriptionSemicolon
-    case clauseList
+    case trailingSemicolon
   }
 
-  public convenience init(ascription: AscriptionSyntax, ascriptionSemicolon: TokenSyntax, clauseList: FunctionClauseListSyntax) {
+  public convenience init(ascription: AscriptionSyntax, trailingSemicolon: TokenSyntax) {
     let raw = RawSyntax.node(.functionDecl, [
       ascription.raw,
-      ascriptionSemicolon.raw,
-      clauseList.raw,
+      trailingSemicolon.raw,
     ], .present)
     let data = SyntaxData(raw: raw, indexInParent: 0, parent: nil)
     self.init(root: data, data: data)
@@ -780,47 +778,29 @@ public class FunctionDeclSyntax: DeclSyntax {
     return FunctionDeclSyntax(root: newRoot, data: newData)
   }
 
-  public var ascriptionSemicolon: TokenSyntax {
-    return child(at: Cursor.ascriptionSemicolon) as! TokenSyntax
+  public var trailingSemicolon: TokenSyntax {
+    return child(at: Cursor.trailingSemicolon) as! TokenSyntax
   }
-  public func withAscriptionSemicolon(_ syntax: TokenSyntax) -> FunctionDeclSyntax {
-    let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.ascriptionSemicolon)
-    return FunctionDeclSyntax(root: newRoot, data: newData)
-  }
-
-  public var clauseList: FunctionClauseListSyntax {
-    return child(at: Cursor.clauseList) as! FunctionClauseListSyntax
-  }
-  public func withClauseList(_ syntax: FunctionClauseListSyntax) -> FunctionDeclSyntax {
-    let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.clauseList)
+  public func withTrailingSemicolon(_ syntax: TokenSyntax) -> FunctionDeclSyntax {
+    let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.trailingSemicolon)
     return FunctionDeclSyntax(root: newRoot, data: newData)
   }
 
 }
 
-public final class FunctionClauseListSyntax: SyntaxCollection<FunctionClauseSyntax> {
-  internal override init(root: SyntaxData, data: SyntaxData) {
-    super.init(root: root, data: data)
-  }
-  public init(elements: [FunctionClauseSyntax]) {
-    super.init(kind: .functionClauseList, elements: elements)
-  }
-}
-
-public class FunctionClauseSyntax: Syntax {
+public class FunctionClauseDeclSyntax: DeclSyntax {
 
   public convenience init() {
-    let raw = RawSyntax.node(.functionClause, [
+    let raw = RawSyntax.node(.functionClauseDecl, [
     ], .present)
     let data = SyntaxData(raw: raw, indexInParent: 0, parent: nil)
     self.init(root: data, data: data)
   }
 }
 
-public class WithRuleFunctionClauseSyntax: FunctionClauseSyntax {
+public class WithRuleFunctionClauseDeclSyntax: FunctionClauseDeclSyntax {
   public enum Cursor: Int {
-    case functionName
-    case patternClauseList
+    case basicExprList
     case withToken
     case withExpr
     case withPatternClause
@@ -829,13 +809,12 @@ public class WithRuleFunctionClauseSyntax: FunctionClauseSyntax {
     case trailingSemicolon
   }
 
-  public convenience init(functionName: TokenSyntax, patternClauseList: PatternClauseListSyntax?, withToken: TokenSyntax, withExpr: ExprSyntax, withPatternClause: PatternClauseListSyntax?, equalsToken: TokenSyntax, rhsExpr: ExprSyntax, trailingSemicolon: TokenSyntax) {
-    let raw = RawSyntax.node(.withRuleFunctionClause, [
-      functionName.raw,
-      patternClauseList?.raw ?? RawSyntax.missing(.patternClauseList),
+  public convenience init(basicExprList: BasicExprListSyntax, withToken: TokenSyntax, withExpr: ExprSyntax, withPatternClause: BasicExprListSyntax?, equalsToken: TokenSyntax, rhsExpr: ExprSyntax, trailingSemicolon: TokenSyntax) {
+    let raw = RawSyntax.node(.withRuleFunctionClauseDecl, [
+      basicExprList.raw,
       withToken.raw,
       withExpr.raw,
-      withPatternClause?.raw ?? RawSyntax.missing(.patternClauseList),
+      withPatternClause?.raw ?? RawSyntax.missing(.basicExprList),
       equalsToken.raw,
       rhsExpr.raw,
       trailingSemicolon.raw,
@@ -843,85 +822,75 @@ public class WithRuleFunctionClauseSyntax: FunctionClauseSyntax {
     let data = SyntaxData(raw: raw, indexInParent: 0, parent: nil)
     self.init(root: data, data: data)
   }
-  public var functionName: TokenSyntax {
-    return child(at: Cursor.functionName) as! TokenSyntax
+  public var basicExprList: BasicExprListSyntax {
+    return child(at: Cursor.basicExprList) as! BasicExprListSyntax
   }
-  public func withFunctionName(_ syntax: TokenSyntax) -> WithRuleFunctionClauseSyntax {
-    let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.functionName)
-    return WithRuleFunctionClauseSyntax(root: newRoot, data: newData)
-  }
-
-  public var patternClauseList: PatternClauseListSyntax? {
-    return child(at: Cursor.patternClauseList) as? PatternClauseListSyntax
-  }
-  public func withPatternClauseList(_ syntax: PatternClauseListSyntax) -> WithRuleFunctionClauseSyntax {
-    let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.patternClauseList)
-    return WithRuleFunctionClauseSyntax(root: newRoot, data: newData)
+  public func withBasicExprList(_ syntax: BasicExprListSyntax) -> WithRuleFunctionClauseDeclSyntax {
+    let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.basicExprList)
+    return WithRuleFunctionClauseDeclSyntax(root: newRoot, data: newData)
   }
 
   public var withToken: TokenSyntax {
     return child(at: Cursor.withToken) as! TokenSyntax
   }
-  public func withWithToken(_ syntax: TokenSyntax) -> WithRuleFunctionClauseSyntax {
+  public func withWithToken(_ syntax: TokenSyntax) -> WithRuleFunctionClauseDeclSyntax {
     let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.withToken)
-    return WithRuleFunctionClauseSyntax(root: newRoot, data: newData)
+    return WithRuleFunctionClauseDeclSyntax(root: newRoot, data: newData)
   }
 
   public var withExpr: ExprSyntax {
     return child(at: Cursor.withExpr) as! ExprSyntax
   }
-  public func withWithExpr(_ syntax: ExprSyntax) -> WithRuleFunctionClauseSyntax {
+  public func withWithExpr(_ syntax: ExprSyntax) -> WithRuleFunctionClauseDeclSyntax {
     let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.withExpr)
-    return WithRuleFunctionClauseSyntax(root: newRoot, data: newData)
+    return WithRuleFunctionClauseDeclSyntax(root: newRoot, data: newData)
   }
 
-  public var withPatternClause: PatternClauseListSyntax? {
-    return child(at: Cursor.withPatternClause) as? PatternClauseListSyntax
+  public var withPatternClause: BasicExprListSyntax? {
+    return child(at: Cursor.withPatternClause) as? BasicExprListSyntax
   }
-  public func withWithPatternClause(_ syntax: PatternClauseListSyntax) -> WithRuleFunctionClauseSyntax {
+  public func withWithPatternClause(_ syntax: BasicExprListSyntax) -> WithRuleFunctionClauseDeclSyntax {
     let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.withPatternClause)
-    return WithRuleFunctionClauseSyntax(root: newRoot, data: newData)
+    return WithRuleFunctionClauseDeclSyntax(root: newRoot, data: newData)
   }
 
   public var equalsToken: TokenSyntax {
     return child(at: Cursor.equalsToken) as! TokenSyntax
   }
-  public func withEqualsToken(_ syntax: TokenSyntax) -> WithRuleFunctionClauseSyntax {
+  public func withEqualsToken(_ syntax: TokenSyntax) -> WithRuleFunctionClauseDeclSyntax {
     let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.equalsToken)
-    return WithRuleFunctionClauseSyntax(root: newRoot, data: newData)
+    return WithRuleFunctionClauseDeclSyntax(root: newRoot, data: newData)
   }
 
   public var rhsExpr: ExprSyntax {
     return child(at: Cursor.rhsExpr) as! ExprSyntax
   }
-  public func withRhsExpr(_ syntax: ExprSyntax) -> WithRuleFunctionClauseSyntax {
+  public func withRhsExpr(_ syntax: ExprSyntax) -> WithRuleFunctionClauseDeclSyntax {
     let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.rhsExpr)
-    return WithRuleFunctionClauseSyntax(root: newRoot, data: newData)
+    return WithRuleFunctionClauseDeclSyntax(root: newRoot, data: newData)
   }
 
   public var trailingSemicolon: TokenSyntax {
     return child(at: Cursor.trailingSemicolon) as! TokenSyntax
   }
-  public func withTrailingSemicolon(_ syntax: TokenSyntax) -> WithRuleFunctionClauseSyntax {
+  public func withTrailingSemicolon(_ syntax: TokenSyntax) -> WithRuleFunctionClauseDeclSyntax {
     let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.trailingSemicolon)
-    return WithRuleFunctionClauseSyntax(root: newRoot, data: newData)
+    return WithRuleFunctionClauseDeclSyntax(root: newRoot, data: newData)
   }
 
 }
 
-public class NormalFunctionClauseSyntax: FunctionClauseSyntax {
+public class NormalFunctionClauseDeclSyntax: FunctionClauseDeclSyntax {
   public enum Cursor: Int {
-    case functionName
-    case patternClauseList
+    case basicExprList
     case equalsToken
     case rhsExpr
     case trailingSemicolon
   }
 
-  public convenience init(functionName: TokenSyntax, patternClauseList: PatternClauseListSyntax?, equalsToken: TokenSyntax, rhsExpr: ExprSyntax, trailingSemicolon: TokenSyntax) {
-    let raw = RawSyntax.node(.normalFunctionClause, [
-      functionName.raw,
-      patternClauseList?.raw ?? RawSyntax.missing(.patternClauseList),
+  public convenience init(basicExprList: BasicExprListSyntax, equalsToken: TokenSyntax, rhsExpr: ExprSyntax, trailingSemicolon: TokenSyntax) {
+    let raw = RawSyntax.node(.normalFunctionClauseDecl, [
+      basicExprList.raw,
       equalsToken.raw,
       rhsExpr.raw,
       trailingSemicolon.raw,
@@ -929,55 +898,38 @@ public class NormalFunctionClauseSyntax: FunctionClauseSyntax {
     let data = SyntaxData(raw: raw, indexInParent: 0, parent: nil)
     self.init(root: data, data: data)
   }
-  public var functionName: TokenSyntax {
-    return child(at: Cursor.functionName) as! TokenSyntax
+  public var basicExprList: BasicExprListSyntax {
+    return child(at: Cursor.basicExprList) as! BasicExprListSyntax
   }
-  public func withFunctionName(_ syntax: TokenSyntax) -> NormalFunctionClauseSyntax {
-    let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.functionName)
-    return NormalFunctionClauseSyntax(root: newRoot, data: newData)
-  }
-
-  public var patternClauseList: PatternClauseListSyntax? {
-    return child(at: Cursor.patternClauseList) as? PatternClauseListSyntax
-  }
-  public func withPatternClauseList(_ syntax: PatternClauseListSyntax) -> NormalFunctionClauseSyntax {
-    let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.patternClauseList)
-    return NormalFunctionClauseSyntax(root: newRoot, data: newData)
+  public func withBasicExprList(_ syntax: BasicExprListSyntax) -> NormalFunctionClauseDeclSyntax {
+    let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.basicExprList)
+    return NormalFunctionClauseDeclSyntax(root: newRoot, data: newData)
   }
 
   public var equalsToken: TokenSyntax {
     return child(at: Cursor.equalsToken) as! TokenSyntax
   }
-  public func withEqualsToken(_ syntax: TokenSyntax) -> NormalFunctionClauseSyntax {
+  public func withEqualsToken(_ syntax: TokenSyntax) -> NormalFunctionClauseDeclSyntax {
     let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.equalsToken)
-    return NormalFunctionClauseSyntax(root: newRoot, data: newData)
+    return NormalFunctionClauseDeclSyntax(root: newRoot, data: newData)
   }
 
   public var rhsExpr: ExprSyntax {
     return child(at: Cursor.rhsExpr) as! ExprSyntax
   }
-  public func withRhsExpr(_ syntax: ExprSyntax) -> NormalFunctionClauseSyntax {
+  public func withRhsExpr(_ syntax: ExprSyntax) -> NormalFunctionClauseDeclSyntax {
     let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.rhsExpr)
-    return NormalFunctionClauseSyntax(root: newRoot, data: newData)
+    return NormalFunctionClauseDeclSyntax(root: newRoot, data: newData)
   }
 
   public var trailingSemicolon: TokenSyntax {
     return child(at: Cursor.trailingSemicolon) as! TokenSyntax
   }
-  public func withTrailingSemicolon(_ syntax: TokenSyntax) -> NormalFunctionClauseSyntax {
+  public func withTrailingSemicolon(_ syntax: TokenSyntax) -> NormalFunctionClauseDeclSyntax {
     let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.trailingSemicolon)
-    return NormalFunctionClauseSyntax(root: newRoot, data: newData)
+    return NormalFunctionClauseDeclSyntax(root: newRoot, data: newData)
   }
 
-}
-
-public final class PatternClauseListSyntax: SyntaxCollection<ExprSyntax> {
-  internal override init(root: SyntaxData, data: SyntaxData) {
-    super.init(root: root, data: data)
-  }
-  public init(elements: [ExprSyntax]) {
-    super.init(kind: .patternClauseList, elements: elements)
-  }
 }
 
 public class TypedParameterArrowExprSyntax: ExprSyntax {
@@ -1018,48 +970,6 @@ public class TypedParameterArrowExprSyntax: ExprSyntax {
   public func withOutputExpr(_ syntax: ExprSyntax) -> TypedParameterArrowExprSyntax {
     let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.outputExpr)
     return TypedParameterArrowExprSyntax(root: newRoot, data: newData)
-  }
-
-}
-
-public class BasicExprListArrowExprSyntax: ExprSyntax {
-  public enum Cursor: Int {
-    case exprList
-    case arrowToken
-    case outputExpr
-  }
-
-  public convenience init(exprList: BasicExprListSyntax, arrowToken: TokenSyntax, outputExpr: ExprSyntax) {
-    let raw = RawSyntax.node(.basicExprListArrowExpr, [
-      exprList.raw,
-      arrowToken.raw,
-      outputExpr.raw,
-    ], .present)
-    let data = SyntaxData(raw: raw, indexInParent: 0, parent: nil)
-    self.init(root: data, data: data)
-  }
-  public var exprList: BasicExprListSyntax {
-    return child(at: Cursor.exprList) as! BasicExprListSyntax
-  }
-  public func withExprList(_ syntax: BasicExprListSyntax) -> BasicExprListArrowExprSyntax {
-    let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.exprList)
-    return BasicExprListArrowExprSyntax(root: newRoot, data: newData)
-  }
-
-  public var arrowToken: TokenSyntax {
-    return child(at: Cursor.arrowToken) as! TokenSyntax
-  }
-  public func withArrowToken(_ syntax: TokenSyntax) -> BasicExprListArrowExprSyntax {
-    let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.arrowToken)
-    return BasicExprListArrowExprSyntax(root: newRoot, data: newData)
-  }
-
-  public var outputExpr: ExprSyntax {
-    return child(at: Cursor.outputExpr) as! ExprSyntax
-  }
-  public func withOutputExpr(_ syntax: ExprSyntax) -> BasicExprListArrowExprSyntax {
-    let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.outputExpr)
-    return BasicExprListArrowExprSyntax(root: newRoot, data: newData)
   }
 
 }

--- a/Sources/SyntaxGen/SyntaxNodes.swift
+++ b/Sources/SyntaxGen/SyntaxNodes.swift
@@ -167,51 +167,34 @@ let syntaxNodes = [
 
   /// MARK: Functions
 
-  // function-decl ::= <ascription> <function-clause-list>
+  // function-decl ::= <ascription>
 
   Node("FunctionDecl", kind: "Decl", children: [
     Child("ascription", kind: "Ascription"),
-    Child("ascriptionSemicolon", kind: "SemicolonToken"),
-    Child("clauseList", kind: "FunctionClauseList"),
+    Child("trailingSemicolon", kind: "SemicolonToken"),
   ]),
 
-  // function-clause-list ::= <function-clause>
-  //                        | <function-clause> <function-clause-list>
+  // function-clause ::= <basic-expr-list> with <expr> '|' <basic-expr-list>? '=' <expr>
+  //                   | <basic-expr-list> '=' <expr>
 
-  Node("FunctionClauseList", element: "FunctionClause"),
+  Node("FunctionClauseDecl", kind: "Decl", children: []),
 
-  // function-clause ::= <id> <pattern-clause-list>? with <expr> '|' <pattern-clause-list>? '=' <expr>
-  //                   | <id> <pattern-clause-list>? '=' <expr>
-
-  Node("FunctionClause", kind: "Syntax", children: []),
-
-  Node("WithRuleFunctionClause", kind: "FunctionClause", children: [
-    Child("functionName", kind: "IdentifierToken"),
-    Child("patternClauseList", kind: "PatternClauseList", isOptional: true),
+  Node("WithRuleFunctionClauseDecl", kind: "FunctionClauseDecl", children: [
+    Child("basicExprList", kind: "BasicExprList"),
     Child("withToken", kind: "WithToken"),
     Child("withExpr", kind: "Expr"),
-    Child("withPatternClause", kind: "PatternClauseList", isOptional: true),
+    Child("withPatternClause", kind: "BasicExprList", isOptional: true),
     Child("equalsToken", kind: "EqualsToken"),
     Child("rhsExpr", kind: "Expr"),
     Child("trailingSemicolon", kind: "SemicolonToken"),
   ]),
 
-  Node("NormalFunctionClause", kind: "FunctionClause", children: [
-    Child("functionName", kind: "IdentifierToken"),
-    Child("patternClauseList", kind: "PatternClauseList", isOptional: true),
+  Node("NormalFunctionClauseDecl", kind: "FunctionClauseDecl", children: [
+    Child("basicExprList", kind: "BasicExprList"),
     Child("equalsToken", kind: "EqualsToken"),
     Child("rhsExpr", kind: "Expr"),
     Child("trailingSemicolon", kind: "SemicolonToken"),
   ]),
-
-
-  /// MARK: Patterns
-
-  // pattern-clause-list ::= <pattern-clause>
-  //                       | <pattern-clause> <patter-clause-list>
-  // pattern-clause ::= <expr>
-
-  Node("PatternClauseList", element: "Expr"),
 
   // Expressions
 
@@ -225,12 +208,6 @@ let syntaxNodes = [
 
   Node("TypedParameterArrowExpr", kind: "Expr", children: [
     Child("parameters", kind: "TypedParameterList"),
-    Child("arrowToken", kind: "ArrowToken"),
-    Child("outputExpr", kind: "Expr")
-  ]),
-
-  Node("BasicExprListArrowExpr", kind: "Expr", children: [
-    Child("exprList", kind: "BasicExprList"),
     Child("arrowToken", kind: "ArrowToken"),
     Child("outputExpr", kind: "Expr")
   ]),

--- a/Sources/SyntaxGen/SyntaxNodes.swift
+++ b/Sources/SyntaxGen/SyntaxNodes.swift
@@ -257,14 +257,12 @@ let syntaxNodes = [
   ]),
 
   Node("ApplicationExpr", kind: "Expr", children: [
-    Child("exprs", kind: "ApplicationExprList")
+    Child("exprs", kind: "BasicExprList")
   ]),
 
   Node("BasicExpr", kind: "Expr", children: []),
 
   // application ::= <basic-expr> <application>
-
-  Node("ApplicationExprList", element: "BasicExpr"),
 
   // binding-list ::= <qualified-name>
   //                | <typed-parameter>

--- a/Syntax/silt-layout.bnf
+++ b/Syntax/silt-layout.bnf
@@ -49,15 +49,14 @@ import-decl ::= 'open'? 'import' <qualified-name>
 
 ## Functions
 
-function-decl ::= <ascription> ';' <function-clause-list>
-function-clause-list ::= <function-clause> ';'
-                       | <function-clause> ';' <function-clause-list>
-function-clause ::= <id> <pattern-clause-list>? with <expr> '|' <pattern-clause-list>? '=' <expr>
-                  | <id> <pattern-clause-list>? '=' <expr>
+function-decl ::= <ascription> ';'
+
+function-clause-decl ::= <basic-expr-list> with <expr> '|' <basic-expr-list>? '=' <expr> ';'
+                       | <basic-expr-list> '=' <expr> ';'
 
 # Patterns
 
-pattern-clause-list ::= <pattern-clause>
+basic-expr-list ::= <pattern-clause>
                       | <pattern-clause> <patter-clause-list>
 
 pattern-clause ::= <expr>

--- a/Syntax/silt.bnf
+++ b/Syntax/silt.bnf
@@ -8,6 +8,7 @@ decl ::= <data-decl>
        | <module-decl>
        | <import-decl>
        | <function-decl>
+       | <function-clause-decl>
 
 ## Data types
 
@@ -49,15 +50,14 @@ import-decl ::= 'open'? 'import' <qualified-name>
 
 ## Functions
 
-function-decl ::= <ascription> <function-clause-list>
-function-clause-list ::= <function-clause>
-                       | <function-clause> <function-clause-list>
-function-clause ::= <id> <pattern-clause-list>? with <expr> '|' <pattern-clause-list>? '=' <expr>
-                  | <id> <pattern-clause-list>? '=' <expr>
+function-decl ::= <ascription>
+
+function-clause-decl ::= <basic-expr-list> with <expr> '|' <basic-expr-list>? '=' <expr>
+                       | <basic-expr-list> '=' <expr>
 
 # Patterns
 
-pattern-clause-list ::= <pattern-clause>
+basic-expr-list ::= <pattern-clause>
                       | <pattern-clause> <patter-clause-list>
 
 pattern-clause ::= <expr>

--- a/Tests/SyntaxTests/Resources/basics.silt
+++ b/Tests/SyntaxTests/Resources/basics.silt
@@ -8,10 +8,10 @@ flip : forall {a b c : Level} {A : Type a} {B : Type b} {C : A -> B -> Type c} -
               ((x : A) (y : B) -> C x y) -> ((y : B) (x : A) -> C x y)
 flip f = \ y x -> f x y
 
-_ o _ : forall {i j k : Level}
-               {A : Type i}{B : A -> Type j}{C : (a : A) -> B a -> Type k} ->
-               (f : {a : A}(b : B a) -> C a b) ->
-               (g : (a : A) -> B a) ->
-               (a : A) -> C a (g a)
+_o_ : forall {i j k : Level}
+             {A : Type i}{B : A -> Type j}{C : (a : A) -> B a -> Type k} ->
+             (f : {a : A}(b : B a) -> C a b) ->
+             (g : (a : A) -> B a) ->
+             (a : A) -> C a (g a)
 f o g = \ a -> f (g a)
 

--- a/Tests/SyntaxTests/Resources/basics.silt.ast
+++ b/Tests/SyntaxTests/Resources/basics.silt.ast
@@ -1,539 +1,575 @@
-//CHECK: (moduleDecl basics.silt:2:0
-//CHECK-NEXT:   (moduleKeyword basics.silt:2:0)
-//CHECK-NEXT:   (qualifiedName basics.silt:2:7
-//CHECK-NEXT:     (qualifiedNamePiece basics.silt:2:7
-//CHECK-NEXT:       (identifier "Basics" basics.silt:2:7)))
-//CHECK-NEXT:   (typedParameterList)
-//CHECK-NEXT:   (whereKeyword basics.silt:2:14)
-//CHECK-NEXT:   (declList basics.silt:4:0
-//CHECK-NEXT:     (functionDecl basics.silt:4:0
-//CHECK-NEXT:       (ascription basics.silt:4:0
-//CHECK-NEXT:         (identifierList basics.silt:4:0
-//CHECK-NEXT:           (identifier "id" basics.silt:4:0))
-//CHECK-NEXT:         (colon basics.silt:4:3)
-//CHECK-NEXT:         (quantifiedExpr basics.silt:4:5
-//CHECK-NEXT:           (forallKeyword basics.silt:4:5)
-//CHECK-NEXT:           (typedParameterList basics.silt:4:12
-//CHECK-NEXT:             (implicitTypedParameter basics.silt:4:12
-//CHECK-NEXT:               (leftBrace basics.silt:4:12)
-//CHECK-NEXT:               (ascription basics.silt:4:13
-//CHECK-NEXT:                 (identifierList basics.silt:4:13
-//CHECK-NEXT:                   (identifier "k" basics.silt:4:13))
-//CHECK-NEXT:                 (colon basics.silt:4:15)
-//CHECK-NEXT:                 (namedBasicExpr basics.silt:4:17
-//CHECK-NEXT:                   (qualifiedName basics.silt:4:17
-//CHECK-NEXT:                     (qualifiedNamePiece basics.silt:4:17
-//CHECK-NEXT:                       (identifier "Level" basics.silt:4:17)))))
-//CHECK-NEXT:               (rightBrace basics.silt:4:22))
-//CHECK-NEXT:             (implicitTypedParameter basics.silt:4:24
-//CHECK-NEXT:               (leftBrace basics.silt:4:24)
-//CHECK-NEXT:               (ascription basics.silt:4:25
-//CHECK-NEXT:                 (identifierList basics.silt:4:25
-//CHECK-NEXT:                   (identifier "X" basics.silt:4:25))
-//CHECK-NEXT:                 (colon basics.silt:4:27)
-//CHECK-NEXT:                 (applicationExpr basics.silt:4:29
-//CHECK-NEXT:                   (applicationExprList basics.silt:4:29
-//CHECK-NEXT:                     (typeBasicExpr basics.silt:4:29
-//CHECK-NEXT:                       (typeKeyword basics.silt:4:29))
-//CHECK-NEXT:                     (namedBasicExpr basics.silt:4:34
-//CHECK-NEXT:                       (qualifiedName basics.silt:4:34
-//CHECK-NEXT:                         (qualifiedNamePiece basics.silt:4:34
-//CHECK-NEXT:                           (identifier "k" basics.silt:4:34)))))))
-//CHECK-NEXT:               (rightBrace basics.silt:4:35)))
-//CHECK-NEXT:           (arrow basics.silt:4:37)
-//CHECK-NEXT:           (basicExprListArrowExpr basics.silt:4:40
-//CHECK-NEXT:             (basicExprList basics.silt:4:40
-//CHECK-NEXT:               (namedBasicExpr basics.silt:4:40
-//CHECK-NEXT:                 (qualifiedName basics.silt:4:40
-//CHECK-NEXT:                   (qualifiedNamePiece basics.silt:4:40
-//CHECK-NEXT:                     (identifier "X" basics.silt:4:40)))))
-//CHECK-NEXT:             (arrow basics.silt:4:42)
-//CHECK-NEXT:             (namedBasicExpr basics.silt:4:45
-//CHECK-NEXT:               (qualifiedName basics.silt:4:45
-//CHECK-NEXT:                 (qualifiedNamePiece basics.silt:4:45
-//CHECK-NEXT:                   (identifier "X" basics.silt:4:45)))))))
-//CHECK-NEXT:       (functionClauseList basics.silt:5:0
-//CHECK-NEXT:         (normalFunctionClause basics.silt:5:0
-//CHECK-NEXT:           (identifier "id" basics.silt:5:0)
-//CHECK-NEXT:           (patternClauseList basics.silt:5:3
-//CHECK-NEXT:             (namedBasicExpr basics.silt:5:3
-//CHECK-NEXT:               (qualifiedName basics.silt:5:3
-//CHECK-NEXT:                 (qualifiedNamePiece basics.silt:5:3
-//CHECK-NEXT:                   (identifier "x" basics.silt:5:3)))))
-//CHECK-NEXT:           (equals basics.silt:5:5)
-//CHECK-NEXT:           (namedBasicExpr basics.silt:5:7
-//CHECK-NEXT:             (qualifiedName basics.silt:5:7
-//CHECK-NEXT:               (qualifiedNamePiece basics.silt:5:7
-//CHECK-NEXT:                 (identifier "x" basics.silt:5:7)))))))
-//CHECK-NEXT:     (functionDecl basics.silt:7:0
-//CHECK-NEXT:       (ascription basics.silt:7:0
-//CHECK-NEXT:         (identifierList basics.silt:7:0
-//CHECK-NEXT:           (identifier "flip" basics.silt:7:0))
-//CHECK-NEXT:         (colon basics.silt:7:5)
-//CHECK-NEXT:         (quantifiedExpr basics.silt:7:7
-//CHECK-NEXT:           (forallKeyword basics.silt:7:7)
-//CHECK-NEXT:           (typedParameterList basics.silt:7:14
-//CHECK-NEXT:             (implicitTypedParameter basics.silt:7:14
-//CHECK-NEXT:               (leftBrace basics.silt:7:14)
-//CHECK-NEXT:               (ascription basics.silt:7:15
-//CHECK-NEXT:                 (identifierList basics.silt:7:15
-//CHECK-NEXT:                   (identifier "a" basics.silt:7:15)
-//CHECK-NEXT:                   (identifier "b" basics.silt:7:17)
-//CHECK-NEXT:                   (identifier "c" basics.silt:7:19))
-//CHECK-NEXT:                 (colon basics.silt:7:21)
-//CHECK-NEXT:                 (namedBasicExpr basics.silt:7:23
-//CHECK-NEXT:                   (qualifiedName basics.silt:7:23
-//CHECK-NEXT:                     (qualifiedNamePiece basics.silt:7:23
-//CHECK-NEXT:                       (identifier "Level" basics.silt:7:23)))))
-//CHECK-NEXT:               (rightBrace basics.silt:7:28))
-//CHECK-NEXT:             (implicitTypedParameter basics.silt:7:30
-//CHECK-NEXT:               (leftBrace basics.silt:7:30)
-//CHECK-NEXT:               (ascription basics.silt:7:31
-//CHECK-NEXT:                 (identifierList basics.silt:7:31
-//CHECK-NEXT:                   (identifier "A" basics.silt:7:31))
-//CHECK-NEXT:                 (colon basics.silt:7:33)
-//CHECK-NEXT:                 (applicationExpr basics.silt:7:35
-//CHECK-NEXT:                   (applicationExprList basics.silt:7:35
-//CHECK-NEXT:                     (typeBasicExpr basics.silt:7:35
-//CHECK-NEXT:                       (typeKeyword basics.silt:7:35))
-//CHECK-NEXT:                     (namedBasicExpr basics.silt:7:40
-//CHECK-NEXT:                       (qualifiedName basics.silt:7:40
-//CHECK-NEXT:                         (qualifiedNamePiece basics.silt:7:40
-//CHECK-NEXT:                           (identifier "a" basics.silt:7:40)))))))
-//CHECK-NEXT:               (rightBrace basics.silt:7:41))
-//CHECK-NEXT:             (implicitTypedParameter basics.silt:7:43
-//CHECK-NEXT:               (leftBrace basics.silt:7:43)
-//CHECK-NEXT:               (ascription basics.silt:7:44
-//CHECK-NEXT:                 (identifierList basics.silt:7:44
-//CHECK-NEXT:                   (identifier "B" basics.silt:7:44))
-//CHECK-NEXT:                 (colon basics.silt:7:46)
-//CHECK-NEXT:                 (applicationExpr basics.silt:7:48
-//CHECK-NEXT:                   (applicationExprList basics.silt:7:48
-//CHECK-NEXT:                     (typeBasicExpr basics.silt:7:48
-//CHECK-NEXT:                       (typeKeyword basics.silt:7:48))
-//CHECK-NEXT:                     (namedBasicExpr basics.silt:7:53
-//CHECK-NEXT:                       (qualifiedName basics.silt:7:53
-//CHECK-NEXT:                         (qualifiedNamePiece basics.silt:7:53
-//CHECK-NEXT:                           (identifier "b" basics.silt:7:53)))))))
-//CHECK-NEXT:               (rightBrace basics.silt:7:54))
-//CHECK-NEXT:             (implicitTypedParameter basics.silt:7:56
-//CHECK-NEXT:               (leftBrace basics.silt:7:56)
-//CHECK-NEXT:               (ascription basics.silt:7:57
-//CHECK-NEXT:                 (identifierList basics.silt:7:57
-//CHECK-NEXT:                   (identifier "C" basics.silt:7:57))
-//CHECK-NEXT:                 (colon basics.silt:7:59)
-//CHECK-NEXT:                 (basicExprListArrowExpr basics.silt:7:61
-//CHECK-NEXT:                   (basicExprList basics.silt:7:61
-//CHECK-NEXT:                     (namedBasicExpr basics.silt:7:61
-//CHECK-NEXT:                       (qualifiedName basics.silt:7:61
-//CHECK-NEXT:                         (qualifiedNamePiece basics.silt:7:61
-//CHECK-NEXT:                           (identifier "A" basics.silt:7:61)))))
-//CHECK-NEXT:                   (arrow basics.silt:7:63)
-//CHECK-NEXT:                   (basicExprListArrowExpr basics.silt:7:66
-//CHECK-NEXT:                     (basicExprList basics.silt:7:66
-//CHECK-NEXT:                       (namedBasicExpr basics.silt:7:66
-//CHECK-NEXT:                         (qualifiedName basics.silt:7:66
-//CHECK-NEXT:                           (qualifiedNamePiece basics.silt:7:66
-//CHECK-NEXT:                             (identifier "B" basics.silt:7:66)))))
-//CHECK-NEXT:                     (arrow basics.silt:7:68)
-//CHECK-NEXT:                     (applicationExpr basics.silt:7:71
-//CHECK-NEXT:                       (applicationExprList basics.silt:7:71
-//CHECK-NEXT:                         (typeBasicExpr basics.silt:7:71
-//CHECK-NEXT:                           (typeKeyword basics.silt:7:71))
-//CHECK-NEXT:                         (namedBasicExpr basics.silt:7:76
-//CHECK-NEXT:                           (qualifiedName basics.silt:7:76
-//CHECK-NEXT:                             (qualifiedNamePiece basics.silt:7:76
-//CHECK-NEXT:                               (identifier "c" basics.silt:7:76)))))))))
-//CHECK-NEXT:               (rightBrace basics.silt:7:77)))
-//CHECK-NEXT:           (arrow basics.silt:7:79)
-//CHECK-NEXT:           (basicExprListArrowExpr basics.silt:8:14
-//CHECK-NEXT:             (basicExprList basics.silt:8:14
-//CHECK-NEXT:               (parenthesizedExpr basics.silt:8:14
-//CHECK-NEXT:                 (leftParen basics.silt:8:14)
-//CHECK-NEXT:                 (typedParameterArrowExpr basics.silt:8:15
-//CHECK-NEXT:                   (typedParameterList basics.silt:8:15
-//CHECK-NEXT:                     (explicitTypedParameter basics.silt:8:15
-//CHECK-NEXT:                       (leftParen basics.silt:8:15)
-//CHECK-NEXT:                       (ascription basics.silt:8:16
-//CHECK-NEXT:                         (identifierList basics.silt:8:16
-//CHECK-NEXT:                           (identifier "x" basics.silt:8:16))
-//CHECK-NEXT:                         (colon basics.silt:8:18)
-//CHECK-NEXT:                         (namedBasicExpr basics.silt:8:20
-//CHECK-NEXT:                           (qualifiedName basics.silt:8:20
-//CHECK-NEXT:                             (qualifiedNamePiece basics.silt:8:20
-//CHECK-NEXT:                               (identifier "A" basics.silt:8:20)))))
-//CHECK-NEXT:                       (rightParen basics.silt:8:21))
-//CHECK-NEXT:                     (explicitTypedParameter basics.silt:8:23
-//CHECK-NEXT:                       (leftParen basics.silt:8:23)
-//CHECK-NEXT:                       (ascription basics.silt:8:24
-//CHECK-NEXT:                         (identifierList basics.silt:8:24
-//CHECK-NEXT:                           (identifier "y" basics.silt:8:24))
-//CHECK-NEXT:                         (colon basics.silt:8:26)
-//CHECK-NEXT:                         (namedBasicExpr basics.silt:8:28
-//CHECK-NEXT:                           (qualifiedName basics.silt:8:28
-//CHECK-NEXT:                             (qualifiedNamePiece basics.silt:8:28
-//CHECK-NEXT:                               (identifier "B" basics.silt:8:28)))))
-//CHECK-NEXT:                       (rightParen basics.silt:8:29)))
-//CHECK-NEXT:                   (arrow basics.silt:8:31)
-//CHECK-NEXT:                   (applicationExpr basics.silt:8:34
-//CHECK-NEXT:                     (applicationExprList basics.silt:8:34
-//CHECK-NEXT:                       (namedBasicExpr basics.silt:8:34
-//CHECK-NEXT:                         (qualifiedName basics.silt:8:34
-//CHECK-NEXT:                           (qualifiedNamePiece basics.silt:8:34
-//CHECK-NEXT:                             (identifier "C" basics.silt:8:34))))
-//CHECK-NEXT:                       (namedBasicExpr basics.silt:8:36
-//CHECK-NEXT:                         (qualifiedName basics.silt:8:36
-//CHECK-NEXT:                           (qualifiedNamePiece basics.silt:8:36
-//CHECK-NEXT:                             (identifier "x" basics.silt:8:36))))
-//CHECK-NEXT:                       (namedBasicExpr basics.silt:8:38
-//CHECK-NEXT:                         (qualifiedName basics.silt:8:38
-//CHECK-NEXT:                           (qualifiedNamePiece basics.silt:8:38
-//CHECK-NEXT:                             (identifier "y" basics.silt:8:38)))))))
-//CHECK-NEXT:                 (rightParen basics.silt:8:39)))
-//CHECK-NEXT:             (arrow basics.silt:8:41)
-//CHECK-NEXT:             (parenthesizedExpr basics.silt:8:44
-//CHECK-NEXT:               (leftParen basics.silt:8:44)
-//CHECK-NEXT:               (typedParameterArrowExpr basics.silt:8:45
-//CHECK-NEXT:                 (typedParameterList basics.silt:8:45
-//CHECK-NEXT:                   (explicitTypedParameter basics.silt:8:45
-//CHECK-NEXT:                     (leftParen basics.silt:8:45)
-//CHECK-NEXT:                     (ascription basics.silt:8:46
-//CHECK-NEXT:                       (identifierList basics.silt:8:46
-//CHECK-NEXT:                         (identifier "y" basics.silt:8:46))
-//CHECK-NEXT:                       (colon basics.silt:8:48)
-//CHECK-NEXT:                       (namedBasicExpr basics.silt:8:50
-//CHECK-NEXT:                         (qualifiedName basics.silt:8:50
-//CHECK-NEXT:                           (qualifiedNamePiece basics.silt:8:50
-//CHECK-NEXT:                             (identifier "B" basics.silt:8:50)))))
-//CHECK-NEXT:                     (rightParen basics.silt:8:51))
-//CHECK-NEXT:                   (explicitTypedParameter basics.silt:8:53
-//CHECK-NEXT:                     (leftParen basics.silt:8:53)
-//CHECK-NEXT:                     (ascription basics.silt:8:54
-//CHECK-NEXT:                       (identifierList basics.silt:8:54
-//CHECK-NEXT:                         (identifier "x" basics.silt:8:54))
-//CHECK-NEXT:                       (colon basics.silt:8:56)
-//CHECK-NEXT:                       (namedBasicExpr basics.silt:8:58
-//CHECK-NEXT:                         (qualifiedName basics.silt:8:58
-//CHECK-NEXT:                           (qualifiedNamePiece basics.silt:8:58
-//CHECK-NEXT:                             (identifier "A" basics.silt:8:58)))))
-//CHECK-NEXT:                     (rightParen basics.silt:8:59)))
-//CHECK-NEXT:                 (arrow basics.silt:8:61)
-//CHECK-NEXT:                 (applicationExpr basics.silt:8:64
-//CHECK-NEXT:                   (applicationExprList basics.silt:8:64
-//CHECK-NEXT:                     (namedBasicExpr basics.silt:8:64
-//CHECK-NEXT:                       (qualifiedName basics.silt:8:64
-//CHECK-NEXT:                         (qualifiedNamePiece basics.silt:8:64
-//CHECK-NEXT:                           (identifier "C" basics.silt:8:64))))
-//CHECK-NEXT:                     (namedBasicExpr basics.silt:8:66
-//CHECK-NEXT:                       (qualifiedName basics.silt:8:66
-//CHECK-NEXT:                         (qualifiedNamePiece basics.silt:8:66
-//CHECK-NEXT:                           (identifier "x" basics.silt:8:66))))
-//CHECK-NEXT:                     (namedBasicExpr basics.silt:8:68
-//CHECK-NEXT:                       (qualifiedName basics.silt:8:68
-//CHECK-NEXT:                         (qualifiedNamePiece basics.silt:8:68
-//CHECK-NEXT:                           (identifier "y" basics.silt:8:68)))))))
-//CHECK-NEXT:               (rightParen basics.silt:8:69)))))
-//CHECK-NEXT:       (functionClauseList basics.silt:9:0
-//CHECK-NEXT:         (normalFunctionClause basics.silt:9:0
-//CHECK-NEXT:           (identifier "flip" basics.silt:9:0)
-//CHECK-NEXT:           (patternClauseList basics.silt:9:5
-//CHECK-NEXT:             (namedBasicExpr basics.silt:9:5
-//CHECK-NEXT:               (qualifiedName basics.silt:9:5
-//CHECK-NEXT:                 (qualifiedNamePiece basics.silt:9:5
-//CHECK-NEXT:                   (identifier "f" basics.silt:9:5)))))
-//CHECK-NEXT:           (equals basics.silt:9:7)
-//CHECK-NEXT:           (lambdaExpr basics.silt:9:9
-//CHECK-NEXT:             (forwardSlash basics.silt:9:9)
-//CHECK-NEXT:             (bindingList basics.silt:9:11
-//CHECK-NEXT:               (namedBinding basics.silt:9:11
-//CHECK-NEXT:                 (qualifiedName basics.silt:9:11
-//CHECK-NEXT:                   (qualifiedNamePiece basics.silt:9:11
-//CHECK-NEXT:                     (identifier "y" basics.silt:9:11))))
-//CHECK-NEXT:               (namedBinding basics.silt:9:13
-//CHECK-NEXT:                 (qualifiedName basics.silt:9:13
-//CHECK-NEXT:                   (qualifiedNamePiece basics.silt:9:13
-//CHECK-NEXT:                     (identifier "x" basics.silt:9:13)))))
-//CHECK-NEXT:             (arrow basics.silt:9:15)
-//CHECK-NEXT:             (applicationExpr basics.silt:9:18
-//CHECK-NEXT:               (applicationExprList basics.silt:9:18
-//CHECK-NEXT:                 (namedBasicExpr basics.silt:9:18
-//CHECK-NEXT:                   (qualifiedName basics.silt:9:18
-//CHECK-NEXT:                     (qualifiedNamePiece basics.silt:9:18
-//CHECK-NEXT:                       (identifier "f" basics.silt:9:18))))
-//CHECK-NEXT:                 (namedBasicExpr basics.silt:9:20
-//CHECK-NEXT:                   (qualifiedName basics.silt:9:20
-//CHECK-NEXT:                     (qualifiedNamePiece basics.silt:9:20
-//CHECK-NEXT:                       (identifier "x" basics.silt:9:20))))
-//CHECK-NEXT:                 (namedBasicExpr basics.silt:9:22
-//CHECK-NEXT:                   (qualifiedName basics.silt:9:22
-//CHECK-NEXT:                     (qualifiedNamePiece basics.silt:9:22
-//CHECK-NEXT:                       (identifier "y" basics.silt:9:22))))))))))
-//CHECK-NEXT:     (functionDecl basics.silt:11:0
-//CHECK-NEXT:       (ascription basics.silt:11:0
-//CHECK-NEXT:         (identifierList basics.silt:11:0
-//CHECK-NEXT:           (underscore basics.silt:11:0)
-//CHECK-NEXT:           (identifier "o" basics.silt:11:2)
-//CHECK-NEXT:           (underscore basics.silt:11:4))
-//CHECK-NEXT:         (colon basics.silt:11:6)
-//CHECK-NEXT:         (quantifiedExpr basics.silt:11:8
-//CHECK-NEXT:           (forallKeyword basics.silt:11:8)
-//CHECK-NEXT:           (typedParameterList basics.silt:11:15
-//CHECK-NEXT:             (implicitTypedParameter basics.silt:11:15
-//CHECK-NEXT:               (leftBrace basics.silt:11:15)
-//CHECK-NEXT:               (ascription basics.silt:11:16
-//CHECK-NEXT:                 (identifierList basics.silt:11:16
-//CHECK-NEXT:                   (identifier "i" basics.silt:11:16)
-//CHECK-NEXT:                   (identifier "j" basics.silt:11:18)
-//CHECK-NEXT:                   (identifier "k" basics.silt:11:20))
-//CHECK-NEXT:                 (colon basics.silt:11:22)
-//CHECK-NEXT:                 (namedBasicExpr basics.silt:11:24
-//CHECK-NEXT:                   (qualifiedName basics.silt:11:24
-//CHECK-NEXT:                     (qualifiedNamePiece basics.silt:11:24
-//CHECK-NEXT:                       (identifier "Level" basics.silt:11:24)))))
-//CHECK-NEXT:               (rightBrace basics.silt:11:29))
-//CHECK-NEXT:             (implicitTypedParameter basics.silt:12:15
-//CHECK-NEXT:               (leftBrace basics.silt:12:15)
-//CHECK-NEXT:               (ascription basics.silt:12:16
-//CHECK-NEXT:                 (identifierList basics.silt:12:16
-//CHECK-NEXT:                   (identifier "A" basics.silt:12:16))
-//CHECK-NEXT:                 (colon basics.silt:12:18)
-//CHECK-NEXT:                 (applicationExpr basics.silt:12:20
-//CHECK-NEXT:                   (applicationExprList basics.silt:12:20
-//CHECK-NEXT:                     (typeBasicExpr basics.silt:12:20
-//CHECK-NEXT:                       (typeKeyword basics.silt:12:20))
-//CHECK-NEXT:                     (namedBasicExpr basics.silt:12:25
-//CHECK-NEXT:                       (qualifiedName basics.silt:12:25
-//CHECK-NEXT:                         (qualifiedNamePiece basics.silt:12:25
-//CHECK-NEXT:                           (identifier "i" basics.silt:12:25)))))))
-//CHECK-NEXT:               (rightBrace basics.silt:12:26))
-//CHECK-NEXT:             (implicitTypedParameter basics.silt:12:27
-//CHECK-NEXT:               (leftBrace basics.silt:12:27)
-//CHECK-NEXT:               (ascription basics.silt:12:28
-//CHECK-NEXT:                 (identifierList basics.silt:12:28
-//CHECK-NEXT:                   (identifier "B" basics.silt:12:28))
-//CHECK-NEXT:                 (colon basics.silt:12:30)
-//CHECK-NEXT:                 (basicExprListArrowExpr basics.silt:12:32
-//CHECK-NEXT:                   (basicExprList basics.silt:12:32
-//CHECK-NEXT:                     (namedBasicExpr basics.silt:12:32
-//CHECK-NEXT:                       (qualifiedName basics.silt:12:32
-//CHECK-NEXT:                         (qualifiedNamePiece basics.silt:12:32
-//CHECK-NEXT:                           (identifier "A" basics.silt:12:32)))))
-//CHECK-NEXT:                   (arrow basics.silt:12:34)
-//CHECK-NEXT:                   (applicationExpr basics.silt:12:37
-//CHECK-NEXT:                     (applicationExprList basics.silt:12:37
-//CHECK-NEXT:                       (typeBasicExpr basics.silt:12:37
-//CHECK-NEXT:                         (typeKeyword basics.silt:12:37))
-//CHECK-NEXT:                       (namedBasicExpr basics.silt:12:42
-//CHECK-NEXT:                         (qualifiedName basics.silt:12:42
-//CHECK-NEXT:                           (qualifiedNamePiece basics.silt:12:42
-//CHECK-NEXT:                             (identifier "j" basics.silt:12:42))))))))
-//CHECK-NEXT:               (rightBrace basics.silt:12:43))
-//CHECK-NEXT:             (implicitTypedParameter basics.silt:12:44
-//CHECK-NEXT:               (leftBrace basics.silt:12:44)
-//CHECK-NEXT:               (ascription basics.silt:12:45
-//CHECK-NEXT:                 (identifierList basics.silt:12:45
-//CHECK-NEXT:                   (identifier "C" basics.silt:12:45))
-//CHECK-NEXT:                 (colon basics.silt:12:47)
-//CHECK-NEXT:                 (typedParameterArrowExpr basics.silt:12:49
-//CHECK-NEXT:                   (typedParameterList basics.silt:12:49
-//CHECK-NEXT:                     (explicitTypedParameter basics.silt:12:49
-//CHECK-NEXT:                       (leftParen basics.silt:12:49)
-//CHECK-NEXT:                       (ascription basics.silt:12:50
-//CHECK-NEXT:                         (identifierList basics.silt:12:50
-//CHECK-NEXT:                           (identifier "a" basics.silt:12:50))
-//CHECK-NEXT:                         (colon basics.silt:12:52)
-//CHECK-NEXT:                         (namedBasicExpr basics.silt:12:54
-//CHECK-NEXT:                           (qualifiedName basics.silt:12:54
-//CHECK-NEXT:                             (qualifiedNamePiece basics.silt:12:54
-//CHECK-NEXT:                               (identifier "A" basics.silt:12:54)))))
-//CHECK-NEXT:                       (rightParen basics.silt:12:55)))
-//CHECK-NEXT:                   (arrow basics.silt:12:57)
-//CHECK-NEXT:                   (basicExprListArrowExpr basics.silt:12:60
-//CHECK-NEXT:                     (basicExprList basics.silt:12:60
-//CHECK-NEXT:                       (namedBasicExpr basics.silt:12:60
-//CHECK-NEXT:                         (qualifiedName basics.silt:12:60
-//CHECK-NEXT:                           (qualifiedNamePiece basics.silt:12:60
-//CHECK-NEXT:                             (identifier "B" basics.silt:12:60))))
-//CHECK-NEXT:                       (namedBasicExpr basics.silt:12:62
-//CHECK-NEXT:                         (qualifiedName basics.silt:12:62
-//CHECK-NEXT:                           (qualifiedNamePiece basics.silt:12:62
-//CHECK-NEXT:                             (identifier "a" basics.silt:12:62)))))
-//CHECK-NEXT:                     (arrow basics.silt:12:64)
-//CHECK-NEXT:                     (applicationExpr basics.silt:12:67
-//CHECK-NEXT:                       (applicationExprList basics.silt:12:67
-//CHECK-NEXT:                         (typeBasicExpr basics.silt:12:67
-//CHECK-NEXT:                           (typeKeyword basics.silt:12:67))
-//CHECK-NEXT:                         (namedBasicExpr basics.silt:12:72
-//CHECK-NEXT:                           (qualifiedName basics.silt:12:72
-//CHECK-NEXT:                             (qualifiedNamePiece basics.silt:12:72
-//CHECK-NEXT:                               (identifier "k" basics.silt:12:72)))))))))
-//CHECK-NEXT:               (rightBrace basics.silt:12:73)))
-//CHECK-NEXT:           (arrow basics.silt:12:75)
-//CHECK-NEXT:           (typedParameterArrowExpr basics.silt:13:15
-//CHECK-NEXT:             (typedParameterList basics.silt:13:15
-//CHECK-NEXT:               (explicitTypedParameter basics.silt:13:15
-//CHECK-NEXT:                 (leftParen basics.silt:13:15)
-//CHECK-NEXT:                 (ascription basics.silt:13:16
-//CHECK-NEXT:                   (identifierList basics.silt:13:16
-//CHECK-NEXT:                     (identifier "f" basics.silt:13:16))
-//CHECK-NEXT:                   (colon basics.silt:13:18)
-//CHECK-NEXT:                   (typedParameterArrowExpr basics.silt:13:20
-//CHECK-NEXT:                     (typedParameterList basics.silt:13:20
-//CHECK-NEXT:                       (implicitTypedParameter basics.silt:13:20
-//CHECK-NEXT:                         (leftBrace basics.silt:13:20)
-//CHECK-NEXT:                         (ascription basics.silt:13:21
-//CHECK-NEXT:                           (identifierList basics.silt:13:21
-//CHECK-NEXT:                             (identifier "a" basics.silt:13:21))
-//CHECK-NEXT:                           (colon basics.silt:13:23)
-//CHECK-NEXT:                           (namedBasicExpr basics.silt:13:25
-//CHECK-NEXT:                             (qualifiedName basics.silt:13:25
-//CHECK-NEXT:                               (qualifiedNamePiece basics.silt:13:25
-//CHECK-NEXT:                                 (identifier "A" basics.silt:13:25)))))
-//CHECK-NEXT:                         (rightBrace basics.silt:13:26))
-//CHECK-NEXT:                       (explicitTypedParameter basics.silt:13:27
-//CHECK-NEXT:                         (leftParen basics.silt:13:27)
-//CHECK-NEXT:                         (ascription basics.silt:13:28
-//CHECK-NEXT:                           (identifierList basics.silt:13:28
-//CHECK-NEXT:                             (identifier "b" basics.silt:13:28))
-//CHECK-NEXT:                           (colon basics.silt:13:30)
-//CHECK-NEXT:                           (applicationExpr basics.silt:13:32
-//CHECK-NEXT:                             (applicationExprList basics.silt:13:32
-//CHECK-NEXT:                               (namedBasicExpr basics.silt:13:32
-//CHECK-NEXT:                                 (qualifiedName basics.silt:13:32
-//CHECK-NEXT:                                   (qualifiedNamePiece basics.silt:13:32
-//CHECK-NEXT:                                     (identifier "B" basics.silt:13:32))))
-//CHECK-NEXT:                               (namedBasicExpr basics.silt:13:34
-//CHECK-NEXT:                                 (qualifiedName basics.silt:13:34
-//CHECK-NEXT:                                   (qualifiedNamePiece basics.silt:13:34
-//CHECK-NEXT:                                     (identifier "a" basics.silt:13:34)))))))
-//CHECK-NEXT:                         (rightParen basics.silt:13:35)))
-//CHECK-NEXT:                     (arrow basics.silt:13:37)
-//CHECK-NEXT:                     (applicationExpr basics.silt:13:40
-//CHECK-NEXT:                       (applicationExprList basics.silt:13:40
-//CHECK-NEXT:                         (namedBasicExpr basics.silt:13:40
-//CHECK-NEXT:                           (qualifiedName basics.silt:13:40
-//CHECK-NEXT:                             (qualifiedNamePiece basics.silt:13:40
-//CHECK-NEXT:                               (identifier "C" basics.silt:13:40))))
-//CHECK-NEXT:                         (namedBasicExpr basics.silt:13:42
-//CHECK-NEXT:                           (qualifiedName basics.silt:13:42
-//CHECK-NEXT:                             (qualifiedNamePiece basics.silt:13:42
-//CHECK-NEXT:                               (identifier "a" basics.silt:13:42))))
-//CHECK-NEXT:                         (namedBasicExpr basics.silt:13:44
-//CHECK-NEXT:                           (qualifiedName basics.silt:13:44
-//CHECK-NEXT:                             (qualifiedNamePiece basics.silt:13:44
-//CHECK-NEXT:                               (identifier "b" basics.silt:13:44))))))))
-//CHECK-NEXT:                 (rightParen basics.silt:13:45)))
-//CHECK-NEXT:             (arrow basics.silt:13:47)
-//CHECK-NEXT:             (typedParameterArrowExpr basics.silt:14:15
-//CHECK-NEXT:               (typedParameterList basics.silt:14:15
-//CHECK-NEXT:                 (explicitTypedParameter basics.silt:14:15
-//CHECK-NEXT:                   (leftParen basics.silt:14:15)
-//CHECK-NEXT:                   (ascription basics.silt:14:16
-//CHECK-NEXT:                     (identifierList basics.silt:14:16
-//CHECK-NEXT:                       (identifier "g" basics.silt:14:16))
-//CHECK-NEXT:                     (colon basics.silt:14:18)
-//CHECK-NEXT:                     (typedParameterArrowExpr basics.silt:14:20
-//CHECK-NEXT:                       (typedParameterList basics.silt:14:20
-//CHECK-NEXT:                         (explicitTypedParameter basics.silt:14:20
-//CHECK-NEXT:                           (leftParen basics.silt:14:20)
-//CHECK-NEXT:                           (ascription basics.silt:14:21
-//CHECK-NEXT:                             (identifierList basics.silt:14:21
-//CHECK-NEXT:                               (identifier "a" basics.silt:14:21))
-//CHECK-NEXT:                             (colon basics.silt:14:23)
-//CHECK-NEXT:                             (namedBasicExpr basics.silt:14:25
-//CHECK-NEXT:                               (qualifiedName basics.silt:14:25
-//CHECK-NEXT:                                 (qualifiedNamePiece basics.silt:14:25
-//CHECK-NEXT:                                   (identifier "A" basics.silt:14:25)))))
-//CHECK-NEXT:                           (rightParen basics.silt:14:26)))
-//CHECK-NEXT:                       (arrow basics.silt:14:28)
-//CHECK-NEXT:                       (applicationExpr basics.silt:14:31
-//CHECK-NEXT:                         (applicationExprList basics.silt:14:31
-//CHECK-NEXT:                           (namedBasicExpr basics.silt:14:31
-//CHECK-NEXT:                             (qualifiedName basics.silt:14:31
-//CHECK-NEXT:                               (qualifiedNamePiece basics.silt:14:31
-//CHECK-NEXT:                                 (identifier "B" basics.silt:14:31))))
-//CHECK-NEXT:                           (namedBasicExpr basics.silt:14:33
-//CHECK-NEXT:                             (qualifiedName basics.silt:14:33
-//CHECK-NEXT:                               (qualifiedNamePiece basics.silt:14:33
-//CHECK-NEXT:                                 (identifier "a" basics.silt:14:33))))))))
-//CHECK-NEXT:                   (rightParen basics.silt:14:34)))
-//CHECK-NEXT:               (arrow basics.silt:14:36)
-//CHECK-NEXT:               (typedParameterArrowExpr basics.silt:15:15
-//CHECK-NEXT:                 (typedParameterList basics.silt:15:15
-//CHECK-NEXT:                   (explicitTypedParameter basics.silt:15:15
-//CHECK-NEXT:                     (leftParen basics.silt:15:15)
-//CHECK-NEXT:                     (ascription basics.silt:15:16
-//CHECK-NEXT:                       (identifierList basics.silt:15:16
-//CHECK-NEXT:                         (identifier "a" basics.silt:15:16))
-//CHECK-NEXT:                       (colon basics.silt:15:18)
-//CHECK-NEXT:                       (namedBasicExpr basics.silt:15:20
-//CHECK-NEXT:                         (qualifiedName basics.silt:15:20
-//CHECK-NEXT:                           (qualifiedNamePiece basics.silt:15:20
-//CHECK-NEXT:                             (identifier "A" basics.silt:15:20)))))
-//CHECK-NEXT:                     (rightParen basics.silt:15:21)))
-//CHECK-NEXT:                 (arrow basics.silt:15:23)
-//CHECK-NEXT:                 (applicationExpr basics.silt:15:26
-//CHECK-NEXT:                   (applicationExprList basics.silt:15:26
-//CHECK-NEXT:                     (namedBasicExpr basics.silt:15:26
-//CHECK-NEXT:                       (qualifiedName basics.silt:15:26
-//CHECK-NEXT:                         (qualifiedNamePiece basics.silt:15:26
-//CHECK-NEXT:                           (identifier "C" basics.silt:15:26))))
-//CHECK-NEXT:                     (namedBasicExpr basics.silt:15:28
-//CHECK-NEXT:                       (qualifiedName basics.silt:15:28
-//CHECK-NEXT:                         (qualifiedNamePiece basics.silt:15:28
-//CHECK-NEXT:                           (identifier "a" basics.silt:15:28))))
-//CHECK-NEXT:                     (parenthesizedExpr basics.silt:15:30
-//CHECK-NEXT:                       (leftParen basics.silt:15:30)
-//CHECK-NEXT:                       (applicationExpr basics.silt:15:31
-//CHECK-NEXT:                         (applicationExprList basics.silt:15:31
-//CHECK-NEXT:                           (namedBasicExpr basics.silt:15:31
-//CHECK-NEXT:                             (qualifiedName basics.silt:15:31
-//CHECK-NEXT:                               (qualifiedNamePiece basics.silt:15:31
-//CHECK-NEXT:                                 (identifier "g" basics.silt:15:31))))
-//CHECK-NEXT:                           (namedBasicExpr basics.silt:15:33
-//CHECK-NEXT:                             (qualifiedName basics.silt:15:33
-//CHECK-NEXT:                               (qualifiedNamePiece basics.silt:15:33
-//CHECK-NEXT:                                 (identifier "a" basics.silt:15:33))))))
-//CHECK-NEXT:                       (rightParen basics.silt:15:34)))))))))
-//CHECK-NEXT:       (functionClauseList basics.silt:16:0
-//CHECK-NEXT:         (normalFunctionClause basics.silt:16:0
-//CHECK-NEXT:           (identifier "f" basics.silt:16:0)
-//CHECK-NEXT:           (patternClauseList basics.silt:16:2
-//CHECK-NEXT:             (applicationExpr basics.silt:16:2
-//CHECK-NEXT:               (applicationExprList basics.silt:16:2
-//CHECK-NEXT:                 (namedBasicExpr basics.silt:16:2
-//CHECK-NEXT:                   (qualifiedName basics.silt:16:2
-//CHECK-NEXT:                     (qualifiedNamePiece basics.silt:16:2
-//CHECK-NEXT:                       (identifier "o" basics.silt:16:2))))
-//CHECK-NEXT:                 (namedBasicExpr basics.silt:16:4
-//CHECK-NEXT:                   (qualifiedName basics.silt:16:4
-//CHECK-NEXT:                     (qualifiedNamePiece basics.silt:16:4
-//CHECK-NEXT:                       (identifier "g" basics.silt:16:4)))))))
-//CHECK-NEXT:           (equals basics.silt:16:6)
-//CHECK-NEXT:           (lambdaExpr basics.silt:16:8
-//CHECK-NEXT:             (forwardSlash basics.silt:16:8)
-//CHECK-NEXT:             (bindingList basics.silt:16:10
-//CHECK-NEXT:               (namedBinding basics.silt:16:10
-//CHECK-NEXT:                 (qualifiedName basics.silt:16:10
-//CHECK-NEXT:                   (qualifiedNamePiece basics.silt:16:10
-//CHECK-NEXT:                     (identifier "a" basics.silt:16:10)))))
-//CHECK-NEXT:             (arrow basics.silt:16:12)
-//CHECK-NEXT:             (applicationExpr basics.silt:16:15
-//CHECK-NEXT:               (applicationExprList basics.silt:16:15
-//CHECK-NEXT:                 (namedBasicExpr basics.silt:16:15
-//CHECK-NEXT:                   (qualifiedName basics.silt:16:15
-//CHECK-NEXT:                     (qualifiedNamePiece basics.silt:16:15
-//CHECK-NEXT:                       (identifier "f" basics.silt:16:15))))
-//CHECK-NEXT:                 (parenthesizedExpr basics.silt:16:17
-//CHECK-NEXT:                   (leftParen basics.silt:16:17)
-//CHECK-NEXT:                   (applicationExpr basics.silt:16:18
-//CHECK-NEXT:                     (applicationExprList basics.silt:16:18
-//CHECK-NEXT:                       (namedBasicExpr basics.silt:16:18
-//CHECK-NEXT:                         (qualifiedName basics.silt:16:18
-//CHECK-NEXT:                           (qualifiedNamePiece basics.silt:16:18
-//CHECK-NEXT:                             (identifier "g" basics.silt:16:18))))
-//CHECK-NEXT:                       (namedBasicExpr basics.silt:16:20
-//CHECK-NEXT:                         (qualifiedName basics.silt:16:20
-//CHECK-NEXT:                           (qualifiedNamePiece basics.silt:16:20
-//CHECK-NEXT:                             (identifier "a" basics.silt:16:20))))))
-//CHECK-NEXT:                   (rightParen basics.silt:16:21))))))))))
+-- CHECK:      (moduleDecl basics.silt:2:0
+-- CHECK-NEXT:   (moduleKeyword basics.silt:2:0)
+-- CHECK-NEXT:   (qualifiedName basics.silt:2:7
+-- CHECK-NEXT:     (qualifiedNamePiece basics.silt:2:7
+-- CHECK-NEXT:       (identifier "Basics" basics.silt:2:7)))
+-- CHECK-NEXT:   (typedParameterList)
+-- CHECK-NEXT:   (whereKeyword basics.silt:2:14)
+-- CHECK-NEXT:   (declList basics.silt:4:0
+-- CHECK-NEXT:     (functionDecl basics.silt:4:0
+-- CHECK-NEXT:       (ascription basics.silt:4:0
+-- CHECK-NEXT:         (identifierList basics.silt:4:0
+-- CHECK-NEXT:           (identifier "id" basics.silt:4:0))
+-- CHECK-NEXT:         (colon basics.silt:4:3)
+-- CHECK-NEXT:         (quantifiedExpr basics.silt:4:5
+-- CHECK-NEXT:           (forallKeyword basics.silt:4:5)
+-- CHECK-NEXT:           (typedParameterList basics.silt:4:12
+-- CHECK-NEXT:             (implicitTypedParameter basics.silt:4:12
+-- CHECK-NEXT:               (leftBrace basics.silt:4:12)
+-- CHECK-NEXT:               (ascription basics.silt:4:13
+-- CHECK-NEXT:                 (identifierList basics.silt:4:13
+-- CHECK-NEXT:                   (identifier "k" basics.silt:4:13))
+-- CHECK-NEXT:                 (colon basics.silt:4:15)
+-- CHECK-NEXT:                 (applicationExpr basics.silt:4:17
+-- CHECK-NEXT:                   (basicExprList basics.silt:4:17
+-- CHECK-NEXT:                     (namedBasicExpr basics.silt:4:17
+-- CHECK-NEXT:                       (qualifiedName basics.silt:4:17
+-- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:4:17
+-- CHECK-NEXT:                           (identifier "Level" basics.silt:4:17)))))))
+-- CHECK-NEXT:               (rightBrace basics.silt:4:22))
+-- CHECK-NEXT:             (implicitTypedParameter basics.silt:4:24
+-- CHECK-NEXT:               (leftBrace basics.silt:4:24)
+-- CHECK-NEXT:               (ascription basics.silt:4:25
+-- CHECK-NEXT:                 (identifierList basics.silt:4:25
+-- CHECK-NEXT:                   (identifier "X" basics.silt:4:25))
+-- CHECK-NEXT:                 (colon basics.silt:4:27)
+-- CHECK-NEXT:                 (applicationExpr basics.silt:4:29
+-- CHECK-NEXT:                   (basicExprList basics.silt:4:29
+-- CHECK-NEXT:                     (typeBasicExpr basics.silt:4:29
+-- CHECK-NEXT:                       (typeKeyword basics.silt:4:29))
+-- CHECK-NEXT:                     (namedBasicExpr basics.silt:4:34
+-- CHECK-NEXT:                       (qualifiedName basics.silt:4:34
+-- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:4:34
+-- CHECK-NEXT:                           (identifier "k" basics.silt:4:34)))))))
+-- CHECK-NEXT:               (rightBrace basics.silt:4:35)))
+-- CHECK-NEXT:           (arrow basics.silt:4:37)
+-- CHECK-NEXT:           (applicationExpr basics.silt:4:40
+-- CHECK-NEXT:             (basicExprList basics.silt:4:40
+-- CHECK-NEXT:               (namedBasicExpr basics.silt:4:40
+-- CHECK-NEXT:                 (qualifiedName basics.silt:4:40
+-- CHECK-NEXT:                   (qualifiedNamePiece basics.silt:4:40
+-- CHECK-NEXT:                     (identifier "X" basics.silt:4:40))))
+-- CHECK-NEXT:               (namedBasicExpr basics.silt:4:42
+-- CHECK-NEXT:                 (qualifiedName basics.silt:4:42
+-- CHECK-NEXT:                   (qualifiedNamePiece basics.silt:4:42
+-- CHECK-NEXT:                     (arrow basics.silt:4:42))))
+-- CHECK-NEXT:               (namedBasicExpr basics.silt:4:45
+-- CHECK-NEXT:                 (qualifiedName basics.silt:4:45
+-- CHECK-NEXT:                   (qualifiedNamePiece basics.silt:4:45
+-- CHECK-NEXT:                     (identifier "X" basics.silt:4:45)))))))))
+-- CHECK-NEXT:     (normalFunctionClauseDecl basics.silt:5:0
+-- CHECK-NEXT:       (basicExprList basics.silt:5:0
+-- CHECK-NEXT:         (namedBasicExpr basics.silt:5:0
+-- CHECK-NEXT:           (qualifiedName basics.silt:5:0
+-- CHECK-NEXT:             (qualifiedNamePiece basics.silt:5:0
+-- CHECK-NEXT:               (identifier "id" basics.silt:5:0))))
+-- CHECK-NEXT:         (namedBasicExpr basics.silt:5:3
+-- CHECK-NEXT:           (qualifiedName basics.silt:5:3
+-- CHECK-NEXT:             (qualifiedNamePiece basics.silt:5:3
+-- CHECK-NEXT:               (identifier "x" basics.silt:5:3)))))
+-- CHECK-NEXT:       (equals basics.silt:5:5)
+-- CHECK-NEXT:       (applicationExpr basics.silt:5:7
+-- CHECK-NEXT:         (basicExprList basics.silt:5:7
+-- CHECK-NEXT:           (namedBasicExpr basics.silt:5:7
+-- CHECK-NEXT:             (qualifiedName basics.silt:5:7
+-- CHECK-NEXT:               (qualifiedNamePiece basics.silt:5:7
+-- CHECK-NEXT:                 (identifier "x" basics.silt:5:7)))))))
+-- CHECK-NEXT:     (functionDecl basics.silt:7:0
+-- CHECK-NEXT:       (ascription basics.silt:7:0
+-- CHECK-NEXT:         (identifierList basics.silt:7:0
+-- CHECK-NEXT:           (identifier "flip" basics.silt:7:0))
+-- CHECK-NEXT:         (colon basics.silt:7:5)
+-- CHECK-NEXT:         (quantifiedExpr basics.silt:7:7
+-- CHECK-NEXT:           (forallKeyword basics.silt:7:7)
+-- CHECK-NEXT:           (typedParameterList basics.silt:7:14
+-- CHECK-NEXT:             (implicitTypedParameter basics.silt:7:14
+-- CHECK-NEXT:               (leftBrace basics.silt:7:14)
+-- CHECK-NEXT:               (ascription basics.silt:7:15
+-- CHECK-NEXT:                 (identifierList basics.silt:7:15
+-- CHECK-NEXT:                   (identifier "a" basics.silt:7:15)
+-- CHECK-NEXT:                   (identifier "b" basics.silt:7:17)
+-- CHECK-NEXT:                   (identifier "c" basics.silt:7:19))
+-- CHECK-NEXT:                 (colon basics.silt:7:21)
+-- CHECK-NEXT:                 (applicationExpr basics.silt:7:23
+-- CHECK-NEXT:                   (basicExprList basics.silt:7:23
+-- CHECK-NEXT:                     (namedBasicExpr basics.silt:7:23
+-- CHECK-NEXT:                       (qualifiedName basics.silt:7:23
+-- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:7:23
+-- CHECK-NEXT:                           (identifier "Level" basics.silt:7:23)))))))
+-- CHECK-NEXT:               (rightBrace basics.silt:7:28))
+-- CHECK-NEXT:             (implicitTypedParameter basics.silt:7:30
+-- CHECK-NEXT:               (leftBrace basics.silt:7:30)
+-- CHECK-NEXT:               (ascription basics.silt:7:31
+-- CHECK-NEXT:                 (identifierList basics.silt:7:31
+-- CHECK-NEXT:                   (identifier "A" basics.silt:7:31))
+-- CHECK-NEXT:                 (colon basics.silt:7:33)
+-- CHECK-NEXT:                 (applicationExpr basics.silt:7:35
+-- CHECK-NEXT:                   (basicExprList basics.silt:7:35
+-- CHECK-NEXT:                     (typeBasicExpr basics.silt:7:35
+-- CHECK-NEXT:                       (typeKeyword basics.silt:7:35))
+-- CHECK-NEXT:                     (namedBasicExpr basics.silt:7:40
+-- CHECK-NEXT:                       (qualifiedName basics.silt:7:40
+-- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:7:40
+-- CHECK-NEXT:                           (identifier "a" basics.silt:7:40)))))))
+-- CHECK-NEXT:               (rightBrace basics.silt:7:41))
+-- CHECK-NEXT:             (implicitTypedParameter basics.silt:7:43
+-- CHECK-NEXT:               (leftBrace basics.silt:7:43)
+-- CHECK-NEXT:               (ascription basics.silt:7:44
+-- CHECK-NEXT:                 (identifierList basics.silt:7:44
+-- CHECK-NEXT:                   (identifier "B" basics.silt:7:44))
+-- CHECK-NEXT:                 (colon basics.silt:7:46)
+-- CHECK-NEXT:                 (applicationExpr basics.silt:7:48
+-- CHECK-NEXT:                   (basicExprList basics.silt:7:48
+-- CHECK-NEXT:                     (typeBasicExpr basics.silt:7:48
+-- CHECK-NEXT:                       (typeKeyword basics.silt:7:48))
+-- CHECK-NEXT:                     (namedBasicExpr basics.silt:7:53
+-- CHECK-NEXT:                       (qualifiedName basics.silt:7:53
+-- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:7:53
+-- CHECK-NEXT:                           (identifier "b" basics.silt:7:53)))))))
+-- CHECK-NEXT:               (rightBrace basics.silt:7:54))
+-- CHECK-NEXT:             (implicitTypedParameter basics.silt:7:56
+-- CHECK-NEXT:               (leftBrace basics.silt:7:56)
+-- CHECK-NEXT:               (ascription basics.silt:7:57
+-- CHECK-NEXT:                 (identifierList basics.silt:7:57
+-- CHECK-NEXT:                   (identifier "C" basics.silt:7:57))
+-- CHECK-NEXT:                 (colon basics.silt:7:59)
+-- CHECK-NEXT:                 (applicationExpr basics.silt:7:61
+-- CHECK-NEXT:                   (basicExprList basics.silt:7:61
+-- CHECK-NEXT:                     (namedBasicExpr basics.silt:7:61
+-- CHECK-NEXT:                       (qualifiedName basics.silt:7:61
+-- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:7:61
+-- CHECK-NEXT:                           (identifier "A" basics.silt:7:61))))
+-- CHECK-NEXT:                     (namedBasicExpr basics.silt:7:63
+-- CHECK-NEXT:                       (qualifiedName basics.silt:7:63
+-- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:7:63
+-- CHECK-NEXT:                           (arrow basics.silt:7:63))))
+-- CHECK-NEXT:                     (namedBasicExpr basics.silt:7:66
+-- CHECK-NEXT:                       (qualifiedName basics.silt:7:66
+-- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:7:66
+-- CHECK-NEXT:                           (identifier "B" basics.silt:7:66))))
+-- CHECK-NEXT:                     (namedBasicExpr basics.silt:7:68
+-- CHECK-NEXT:                       (qualifiedName basics.silt:7:68
+-- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:7:68
+-- CHECK-NEXT:                           (arrow basics.silt:7:68))))
+-- CHECK-NEXT:                     (typeBasicExpr basics.silt:7:71
+-- CHECK-NEXT:                       (typeKeyword basics.silt:7:71))
+-- CHECK-NEXT:                     (namedBasicExpr basics.silt:7:76
+-- CHECK-NEXT:                       (qualifiedName basics.silt:7:76
+-- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:7:76
+-- CHECK-NEXT:                           (identifier "c" basics.silt:7:76)))))))
+-- CHECK-NEXT:               (rightBrace basics.silt:7:77)))
+-- CHECK-NEXT:           (arrow basics.silt:7:79)
+-- CHECK-NEXT:           (applicationExpr basics.silt:8:14
+-- CHECK-NEXT:             (basicExprList basics.silt:8:14
+-- CHECK-NEXT:               (parenthesizedExpr basics.silt:8:14
+-- CHECK-NEXT:                 (leftParen basics.silt:8:14)
+-- CHECK-NEXT:                 (typedParameterArrowExpr basics.silt:8:15
+-- CHECK-NEXT:                   (typedParameterList basics.silt:8:15
+-- CHECK-NEXT:                     (explicitTypedParameter basics.silt:8:15
+-- CHECK-NEXT:                       (leftParen basics.silt:8:15)
+-- CHECK-NEXT:                       (ascription basics.silt:8:16
+-- CHECK-NEXT:                         (identifierList basics.silt:8:16
+-- CHECK-NEXT:                           (identifier "x" basics.silt:8:16))
+-- CHECK-NEXT:                         (colon basics.silt:8:18)
+-- CHECK-NEXT:                         (applicationExpr basics.silt:8:20
+-- CHECK-NEXT:                           (basicExprList basics.silt:8:20
+-- CHECK-NEXT:                             (namedBasicExpr basics.silt:8:20
+-- CHECK-NEXT:                               (qualifiedName basics.silt:8:20
+-- CHECK-NEXT:                                 (qualifiedNamePiece basics.silt:8:20
+-- CHECK-NEXT:                                   (identifier "A" basics.silt:8:20)))))))
+-- CHECK-NEXT:                       (rightParen basics.silt:8:21))
+-- CHECK-NEXT:                     (explicitTypedParameter basics.silt:8:23
+-- CHECK-NEXT:                       (leftParen basics.silt:8:23)
+-- CHECK-NEXT:                       (ascription basics.silt:8:24
+-- CHECK-NEXT:                         (identifierList basics.silt:8:24
+-- CHECK-NEXT:                           (identifier "y" basics.silt:8:24))
+-- CHECK-NEXT:                         (colon basics.silt:8:26)
+-- CHECK-NEXT:                         (applicationExpr basics.silt:8:28
+-- CHECK-NEXT:                           (basicExprList basics.silt:8:28
+-- CHECK-NEXT:                             (namedBasicExpr basics.silt:8:28
+-- CHECK-NEXT:                               (qualifiedName basics.silt:8:28
+-- CHECK-NEXT:                                 (qualifiedNamePiece basics.silt:8:28
+-- CHECK-NEXT:                                   (identifier "B" basics.silt:8:28)))))))
+-- CHECK-NEXT:                       (rightParen basics.silt:8:29)))
+-- CHECK-NEXT:                   (arrow basics.silt:8:31)
+-- CHECK-NEXT:                   (applicationExpr basics.silt:8:34
+-- CHECK-NEXT:                     (basicExprList basics.silt:8:34
+-- CHECK-NEXT:                       (namedBasicExpr basics.silt:8:34
+-- CHECK-NEXT:                         (qualifiedName basics.silt:8:34
+-- CHECK-NEXT:                           (qualifiedNamePiece basics.silt:8:34
+-- CHECK-NEXT:                             (identifier "C" basics.silt:8:34))))
+-- CHECK-NEXT:                       (namedBasicExpr basics.silt:8:36
+-- CHECK-NEXT:                         (qualifiedName basics.silt:8:36
+-- CHECK-NEXT:                           (qualifiedNamePiece basics.silt:8:36
+-- CHECK-NEXT:                             (identifier "x" basics.silt:8:36))))
+-- CHECK-NEXT:                       (namedBasicExpr basics.silt:8:38
+-- CHECK-NEXT:                         (qualifiedName basics.silt:8:38
+-- CHECK-NEXT:                           (qualifiedNamePiece basics.silt:8:38
+-- CHECK-NEXT:                             (identifier "y" basics.silt:8:38)))))))
+-- CHECK-NEXT:                 (rightParen basics.silt:8:39))
+-- CHECK-NEXT:               (namedBasicExpr basics.silt:8:41
+-- CHECK-NEXT:                 (qualifiedName basics.silt:8:41
+-- CHECK-NEXT:                   (qualifiedNamePiece basics.silt:8:41
+-- CHECK-NEXT:                     (arrow basics.silt:8:41))))
+-- CHECK-NEXT:               (parenthesizedExpr basics.silt:8:44
+-- CHECK-NEXT:                 (leftParen basics.silt:8:44)
+-- CHECK-NEXT:                 (typedParameterArrowExpr basics.silt:8:45
+-- CHECK-NEXT:                   (typedParameterList basics.silt:8:45
+-- CHECK-NEXT:                     (explicitTypedParameter basics.silt:8:45
+-- CHECK-NEXT:                       (leftParen basics.silt:8:45)
+-- CHECK-NEXT:                       (ascription basics.silt:8:46
+-- CHECK-NEXT:                         (identifierList basics.silt:8:46
+-- CHECK-NEXT:                           (identifier "y" basics.silt:8:46))
+-- CHECK-NEXT:                         (colon basics.silt:8:48)
+-- CHECK-NEXT:                         (applicationExpr basics.silt:8:50
+-- CHECK-NEXT:                           (basicExprList basics.silt:8:50
+-- CHECK-NEXT:                             (namedBasicExpr basics.silt:8:50
+-- CHECK-NEXT:                               (qualifiedName basics.silt:8:50
+-- CHECK-NEXT:                                 (qualifiedNamePiece basics.silt:8:50
+-- CHECK-NEXT:                                   (identifier "B" basics.silt:8:50)))))))
+-- CHECK-NEXT:                       (rightParen basics.silt:8:51))
+-- CHECK-NEXT:                     (explicitTypedParameter basics.silt:8:53
+-- CHECK-NEXT:                       (leftParen basics.silt:8:53)
+-- CHECK-NEXT:                       (ascription basics.silt:8:54
+-- CHECK-NEXT:                         (identifierList basics.silt:8:54
+-- CHECK-NEXT:                           (identifier "x" basics.silt:8:54))
+-- CHECK-NEXT:                         (colon basics.silt:8:56)
+-- CHECK-NEXT:                         (applicationExpr basics.silt:8:58
+-- CHECK-NEXT:                           (basicExprList basics.silt:8:58
+-- CHECK-NEXT:                             (namedBasicExpr basics.silt:8:58
+-- CHECK-NEXT:                               (qualifiedName basics.silt:8:58
+-- CHECK-NEXT:                                 (qualifiedNamePiece basics.silt:8:58
+-- CHECK-NEXT:                                   (identifier "A" basics.silt:8:58)))))))
+-- CHECK-NEXT:                       (rightParen basics.silt:8:59)))
+-- CHECK-NEXT:                   (arrow basics.silt:8:61)
+-- CHECK-NEXT:                   (applicationExpr basics.silt:8:64
+-- CHECK-NEXT:                     (basicExprList basics.silt:8:64
+-- CHECK-NEXT:                       (namedBasicExpr basics.silt:8:64
+-- CHECK-NEXT:                         (qualifiedName basics.silt:8:64
+-- CHECK-NEXT:                           (qualifiedNamePiece basics.silt:8:64
+-- CHECK-NEXT:                             (identifier "C" basics.silt:8:64))))
+-- CHECK-NEXT:                       (namedBasicExpr basics.silt:8:66
+-- CHECK-NEXT:                         (qualifiedName basics.silt:8:66
+-- CHECK-NEXT:                           (qualifiedNamePiece basics.silt:8:66
+-- CHECK-NEXT:                             (identifier "x" basics.silt:8:66))))
+-- CHECK-NEXT:                       (namedBasicExpr basics.silt:8:68
+-- CHECK-NEXT:                         (qualifiedName basics.silt:8:68
+-- CHECK-NEXT:                           (qualifiedNamePiece basics.silt:8:68
+-- CHECK-NEXT:                             (identifier "y" basics.silt:8:68)))))))
+-- CHECK-NEXT:                 (rightParen basics.silt:8:69)))))))
+-- CHECK-NEXT:     (normalFunctionClauseDecl basics.silt:9:0
+-- CHECK-NEXT:       (basicExprList basics.silt:9:0
+-- CHECK-NEXT:         (namedBasicExpr basics.silt:9:0
+-- CHECK-NEXT:           (qualifiedName basics.silt:9:0
+-- CHECK-NEXT:             (qualifiedNamePiece basics.silt:9:0
+-- CHECK-NEXT:               (identifier "flip" basics.silt:9:0))))
+-- CHECK-NEXT:         (namedBasicExpr basics.silt:9:5
+-- CHECK-NEXT:           (qualifiedName basics.silt:9:5
+-- CHECK-NEXT:             (qualifiedNamePiece basics.silt:9:5
+-- CHECK-NEXT:               (identifier "f" basics.silt:9:5)))))
+-- CHECK-NEXT:       (equals basics.silt:9:7)
+-- CHECK-NEXT:       (lambdaExpr basics.silt:9:9
+-- CHECK-NEXT:         (forwardSlash basics.silt:9:9)
+-- CHECK-NEXT:         (bindingList basics.silt:9:11
+-- CHECK-NEXT:           (namedBinding basics.silt:9:11
+-- CHECK-NEXT:             (qualifiedName basics.silt:9:11
+-- CHECK-NEXT:               (qualifiedNamePiece basics.silt:9:11
+-- CHECK-NEXT:                 (identifier "y" basics.silt:9:11))))
+-- CHECK-NEXT:           (namedBinding basics.silt:9:13
+-- CHECK-NEXT:             (qualifiedName basics.silt:9:13
+-- CHECK-NEXT:               (qualifiedNamePiece basics.silt:9:13
+-- CHECK-NEXT:                 (identifier "x" basics.silt:9:13)))))
+-- CHECK-NEXT:         (arrow basics.silt:9:15)
+-- CHECK-NEXT:         (applicationExpr basics.silt:9:18
+-- CHECK-NEXT:           (basicExprList basics.silt:9:18
+-- CHECK-NEXT:             (namedBasicExpr basics.silt:9:18
+-- CHECK-NEXT:               (qualifiedName basics.silt:9:18
+-- CHECK-NEXT:                 (qualifiedNamePiece basics.silt:9:18
+-- CHECK-NEXT:                   (identifier "f" basics.silt:9:18))))
+-- CHECK-NEXT:             (namedBasicExpr basics.silt:9:20
+-- CHECK-NEXT:               (qualifiedName basics.silt:9:20
+-- CHECK-NEXT:                 (qualifiedNamePiece basics.silt:9:20
+-- CHECK-NEXT:                   (identifier "x" basics.silt:9:20))))
+-- CHECK-NEXT:             (namedBasicExpr basics.silt:9:22
+-- CHECK-NEXT:               (qualifiedName basics.silt:9:22
+-- CHECK-NEXT:                 (qualifiedNamePiece basics.silt:9:22
+-- CHECK-NEXT:                   (identifier "y" basics.silt:9:22))))))))
+-- CHECK-NEXT:     (functionDecl basics.silt:11:0
+-- CHECK-NEXT:       (ascription basics.silt:11:0
+-- CHECK-NEXT:         (identifierList basics.silt:11:0
+-- CHECK-NEXT:           (identifier "_o_" basics.silt:11:0))
+-- CHECK-NEXT:         (colon basics.silt:11:4)
+-- CHECK-NEXT:         (quantifiedExpr basics.silt:11:6
+-- CHECK-NEXT:           (forallKeyword basics.silt:11:6)
+-- CHECK-NEXT:           (typedParameterList basics.silt:11:13
+-- CHECK-NEXT:             (implicitTypedParameter basics.silt:11:13
+-- CHECK-NEXT:               (leftBrace basics.silt:11:13)
+-- CHECK-NEXT:               (ascription basics.silt:11:14
+-- CHECK-NEXT:                 (identifierList basics.silt:11:14
+-- CHECK-NEXT:                   (identifier "i" basics.silt:11:14)
+-- CHECK-NEXT:                   (identifier "j" basics.silt:11:16)
+-- CHECK-NEXT:                   (identifier "k" basics.silt:11:18))
+-- CHECK-NEXT:                 (colon basics.silt:11:20)
+-- CHECK-NEXT:                 (applicationExpr basics.silt:11:22
+-- CHECK-NEXT:                   (basicExprList basics.silt:11:22
+-- CHECK-NEXT:                     (namedBasicExpr basics.silt:11:22
+-- CHECK-NEXT:                       (qualifiedName basics.silt:11:22
+-- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:11:22
+-- CHECK-NEXT:                           (identifier "Level" basics.silt:11:22)))))))
+-- CHECK-NEXT:               (rightBrace basics.silt:11:27))
+-- CHECK-NEXT:             (implicitTypedParameter basics.silt:12:13
+-- CHECK-NEXT:               (leftBrace basics.silt:12:13)
+-- CHECK-NEXT:               (ascription basics.silt:12:14
+-- CHECK-NEXT:                 (identifierList basics.silt:12:14
+-- CHECK-NEXT:                   (identifier "A" basics.silt:12:14))
+-- CHECK-NEXT:                 (colon basics.silt:12:16)
+-- CHECK-NEXT:                 (applicationExpr basics.silt:12:18
+-- CHECK-NEXT:                   (basicExprList basics.silt:12:18
+-- CHECK-NEXT:                     (typeBasicExpr basics.silt:12:18
+-- CHECK-NEXT:                       (typeKeyword basics.silt:12:18))
+-- CHECK-NEXT:                     (namedBasicExpr basics.silt:12:23
+-- CHECK-NEXT:                       (qualifiedName basics.silt:12:23
+-- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:12:23
+-- CHECK-NEXT:                           (identifier "i" basics.silt:12:23)))))))
+-- CHECK-NEXT:               (rightBrace basics.silt:12:24))
+-- CHECK-NEXT:             (implicitTypedParameter basics.silt:12:25
+-- CHECK-NEXT:               (leftBrace basics.silt:12:25)
+-- CHECK-NEXT:               (ascription basics.silt:12:26
+-- CHECK-NEXT:                 (identifierList basics.silt:12:26
+-- CHECK-NEXT:                   (identifier "B" basics.silt:12:26))
+-- CHECK-NEXT:                 (colon basics.silt:12:28)
+-- CHECK-NEXT:                 (applicationExpr basics.silt:12:30
+-- CHECK-NEXT:                   (basicExprList basics.silt:12:30
+-- CHECK-NEXT:                     (namedBasicExpr basics.silt:12:30
+-- CHECK-NEXT:                       (qualifiedName basics.silt:12:30
+-- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:12:30
+-- CHECK-NEXT:                           (identifier "A" basics.silt:12:30))))
+-- CHECK-NEXT:                     (namedBasicExpr basics.silt:12:32
+-- CHECK-NEXT:                       (qualifiedName basics.silt:12:32
+-- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:12:32
+-- CHECK-NEXT:                           (arrow basics.silt:12:32))))
+-- CHECK-NEXT:                     (typeBasicExpr basics.silt:12:35
+-- CHECK-NEXT:                       (typeKeyword basics.silt:12:35))
+-- CHECK-NEXT:                     (namedBasicExpr basics.silt:12:40
+-- CHECK-NEXT:                       (qualifiedName basics.silt:12:40
+-- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:12:40
+-- CHECK-NEXT:                           (identifier "j" basics.silt:12:40)))))))
+-- CHECK-NEXT:               (rightBrace basics.silt:12:41))
+-- CHECK-NEXT:             (implicitTypedParameter basics.silt:12:42
+-- CHECK-NEXT:               (leftBrace basics.silt:12:42)
+-- CHECK-NEXT:               (ascription basics.silt:12:43
+-- CHECK-NEXT:                 (identifierList basics.silt:12:43
+-- CHECK-NEXT:                   (identifier "C" basics.silt:12:43))
+-- CHECK-NEXT:                 (colon basics.silt:12:45)
+-- CHECK-NEXT:                 (typedParameterArrowExpr basics.silt:12:47
+-- CHECK-NEXT:                   (typedParameterList basics.silt:12:47
+-- CHECK-NEXT:                     (explicitTypedParameter basics.silt:12:47
+-- CHECK-NEXT:                       (leftParen basics.silt:12:47)
+-- CHECK-NEXT:                       (ascription basics.silt:12:48
+-- CHECK-NEXT:                         (identifierList basics.silt:12:48
+-- CHECK-NEXT:                           (identifier "a" basics.silt:12:48))
+-- CHECK-NEXT:                         (colon basics.silt:12:50)
+-- CHECK-NEXT:                         (applicationExpr basics.silt:12:52
+-- CHECK-NEXT:                           (basicExprList basics.silt:12:52
+-- CHECK-NEXT:                             (namedBasicExpr basics.silt:12:52
+-- CHECK-NEXT:                               (qualifiedName basics.silt:12:52
+-- CHECK-NEXT:                                 (qualifiedNamePiece basics.silt:12:52
+-- CHECK-NEXT:                                   (identifier "A" basics.silt:12:52)))))))
+-- CHECK-NEXT:                       (rightParen basics.silt:12:53)))
+-- CHECK-NEXT:                   (arrow basics.silt:12:55)
+-- CHECK-NEXT:                   (applicationExpr basics.silt:12:58
+-- CHECK-NEXT:                     (basicExprList basics.silt:12:58
+-- CHECK-NEXT:                       (namedBasicExpr basics.silt:12:58
+-- CHECK-NEXT:                         (qualifiedName basics.silt:12:58
+-- CHECK-NEXT:                           (qualifiedNamePiece basics.silt:12:58
+-- CHECK-NEXT:                             (identifier "B" basics.silt:12:58))))
+-- CHECK-NEXT:                       (namedBasicExpr basics.silt:12:60
+-- CHECK-NEXT:                         (qualifiedName basics.silt:12:60
+-- CHECK-NEXT:                           (qualifiedNamePiece basics.silt:12:60
+-- CHECK-NEXT:                             (identifier "a" basics.silt:12:60))))
+-- CHECK-NEXT:                       (namedBasicExpr basics.silt:12:62
+-- CHECK-NEXT:                         (qualifiedName basics.silt:12:62
+-- CHECK-NEXT:                           (qualifiedNamePiece basics.silt:12:62
+-- CHECK-NEXT:                             (arrow basics.silt:12:62))))
+-- CHECK-NEXT:                       (typeBasicExpr basics.silt:12:65
+-- CHECK-NEXT:                         (typeKeyword basics.silt:12:65))
+-- CHECK-NEXT:                       (namedBasicExpr basics.silt:12:70
+-- CHECK-NEXT:                         (qualifiedName basics.silt:12:70
+-- CHECK-NEXT:                           (qualifiedNamePiece basics.silt:12:70
+-- CHECK-NEXT:                             (identifier "k" basics.silt:12:70))))))))
+-- CHECK-NEXT:               (rightBrace basics.silt:12:71)))
+-- CHECK-NEXT:           (arrow basics.silt:12:73)
+-- CHECK-NEXT:           (typedParameterArrowExpr basics.silt:13:13
+-- CHECK-NEXT:             (typedParameterList basics.silt:13:13
+-- CHECK-NEXT:               (explicitTypedParameter basics.silt:13:13
+-- CHECK-NEXT:                 (leftParen basics.silt:13:13)
+-- CHECK-NEXT:                 (ascription basics.silt:13:14
+-- CHECK-NEXT:                   (identifierList basics.silt:13:14
+-- CHECK-NEXT:                     (identifier "f" basics.silt:13:14))
+-- CHECK-NEXT:                   (colon basics.silt:13:16)
+-- CHECK-NEXT:                   (typedParameterArrowExpr basics.silt:13:18
+-- CHECK-NEXT:                     (typedParameterList basics.silt:13:18
+-- CHECK-NEXT:                       (implicitTypedParameter basics.silt:13:18
+-- CHECK-NEXT:                         (leftBrace basics.silt:13:18)
+-- CHECK-NEXT:                         (ascription basics.silt:13:19
+-- CHECK-NEXT:                           (identifierList basics.silt:13:19
+-- CHECK-NEXT:                             (identifier "a" basics.silt:13:19))
+-- CHECK-NEXT:                           (colon basics.silt:13:21)
+-- CHECK-NEXT:                           (applicationExpr basics.silt:13:23
+-- CHECK-NEXT:                             (basicExprList basics.silt:13:23
+-- CHECK-NEXT:                               (namedBasicExpr basics.silt:13:23
+-- CHECK-NEXT:                                 (qualifiedName basics.silt:13:23
+-- CHECK-NEXT:                                   (qualifiedNamePiece basics.silt:13:23
+-- CHECK-NEXT:                                     (identifier "A" basics.silt:13:23)))))))
+-- CHECK-NEXT:                         (rightBrace basics.silt:13:24))
+-- CHECK-NEXT:                       (explicitTypedParameter basics.silt:13:25
+-- CHECK-NEXT:                         (leftParen basics.silt:13:25)
+-- CHECK-NEXT:                         (ascription basics.silt:13:26
+-- CHECK-NEXT:                           (identifierList basics.silt:13:26
+-- CHECK-NEXT:                             (identifier "b" basics.silt:13:26))
+-- CHECK-NEXT:                           (colon basics.silt:13:28)
+-- CHECK-NEXT:                           (applicationExpr basics.silt:13:30
+-- CHECK-NEXT:                             (basicExprList basics.silt:13:30
+-- CHECK-NEXT:                               (namedBasicExpr basics.silt:13:30
+-- CHECK-NEXT:                                 (qualifiedName basics.silt:13:30
+-- CHECK-NEXT:                                   (qualifiedNamePiece basics.silt:13:30
+-- CHECK-NEXT:                                     (identifier "B" basics.silt:13:30))))
+-- CHECK-NEXT:                               (namedBasicExpr basics.silt:13:32
+-- CHECK-NEXT:                                 (qualifiedName basics.silt:13:32
+-- CHECK-NEXT:                                   (qualifiedNamePiece basics.silt:13:32
+-- CHECK-NEXT:                                     (identifier "a" basics.silt:13:32)))))))
+-- CHECK-NEXT:                         (rightParen basics.silt:13:33)))
+-- CHECK-NEXT:                     (arrow basics.silt:13:35)
+-- CHECK-NEXT:                     (applicationExpr basics.silt:13:38
+-- CHECK-NEXT:                       (basicExprList basics.silt:13:38
+-- CHECK-NEXT:                         (namedBasicExpr basics.silt:13:38
+-- CHECK-NEXT:                           (qualifiedName basics.silt:13:38
+-- CHECK-NEXT:                             (qualifiedNamePiece basics.silt:13:38
+-- CHECK-NEXT:                               (identifier "C" basics.silt:13:38))))
+-- CHECK-NEXT:                         (namedBasicExpr basics.silt:13:40
+-- CHECK-NEXT:                           (qualifiedName basics.silt:13:40
+-- CHECK-NEXT:                             (qualifiedNamePiece basics.silt:13:40
+-- CHECK-NEXT:                               (identifier "a" basics.silt:13:40))))
+-- CHECK-NEXT:                         (namedBasicExpr basics.silt:13:42
+-- CHECK-NEXT:                           (qualifiedName basics.silt:13:42
+-- CHECK-NEXT:                             (qualifiedNamePiece basics.silt:13:42
+-- CHECK-NEXT:                               (identifier "b" basics.silt:13:42))))))))
+-- CHECK-NEXT:                 (rightParen basics.silt:13:43)))
+-- CHECK-NEXT:             (arrow basics.silt:13:45)
+-- CHECK-NEXT:             (typedParameterArrowExpr basics.silt:14:13
+-- CHECK-NEXT:               (typedParameterList basics.silt:14:13
+-- CHECK-NEXT:                 (explicitTypedParameter basics.silt:14:13
+-- CHECK-NEXT:                   (leftParen basics.silt:14:13)
+-- CHECK-NEXT:                   (ascription basics.silt:14:14
+-- CHECK-NEXT:                     (identifierList basics.silt:14:14
+-- CHECK-NEXT:                       (identifier "g" basics.silt:14:14))
+-- CHECK-NEXT:                     (colon basics.silt:14:16)
+-- CHECK-NEXT:                     (typedParameterArrowExpr basics.silt:14:18
+-- CHECK-NEXT:                       (typedParameterList basics.silt:14:18
+-- CHECK-NEXT:                         (explicitTypedParameter basics.silt:14:18
+-- CHECK-NEXT:                           (leftParen basics.silt:14:18)
+-- CHECK-NEXT:                           (ascription basics.silt:14:19
+-- CHECK-NEXT:                             (identifierList basics.silt:14:19
+-- CHECK-NEXT:                               (identifier "a" basics.silt:14:19))
+-- CHECK-NEXT:                             (colon basics.silt:14:21)
+-- CHECK-NEXT:                             (applicationExpr basics.silt:14:23
+-- CHECK-NEXT:                               (basicExprList basics.silt:14:23
+-- CHECK-NEXT:                                 (namedBasicExpr basics.silt:14:23
+-- CHECK-NEXT:                                   (qualifiedName basics.silt:14:23
+-- CHECK-NEXT:                                     (qualifiedNamePiece basics.silt:14:23
+-- CHECK-NEXT:                                       (identifier "A" basics.silt:14:23)))))))
+-- CHECK-NEXT:                           (rightParen basics.silt:14:24)))
+-- CHECK-NEXT:                       (arrow basics.silt:14:26)
+-- CHECK-NEXT:                       (applicationExpr basics.silt:14:29
+-- CHECK-NEXT:                         (basicExprList basics.silt:14:29
+-- CHECK-NEXT:                           (namedBasicExpr basics.silt:14:29
+-- CHECK-NEXT:                             (qualifiedName basics.silt:14:29
+-- CHECK-NEXT:                               (qualifiedNamePiece basics.silt:14:29
+-- CHECK-NEXT:                                 (identifier "B" basics.silt:14:29))))
+-- CHECK-NEXT:                           (namedBasicExpr basics.silt:14:31
+-- CHECK-NEXT:                             (qualifiedName basics.silt:14:31
+-- CHECK-NEXT:                               (qualifiedNamePiece basics.silt:14:31
+-- CHECK-NEXT:                                 (identifier "a" basics.silt:14:31))))))))
+-- CHECK-NEXT:                   (rightParen basics.silt:14:32)))
+-- CHECK-NEXT:               (arrow basics.silt:14:34)
+-- CHECK-NEXT:               (typedParameterArrowExpr basics.silt:15:13
+-- CHECK-NEXT:                 (typedParameterList basics.silt:15:13
+-- CHECK-NEXT:                   (explicitTypedParameter basics.silt:15:13
+-- CHECK-NEXT:                     (leftParen basics.silt:15:13)
+-- CHECK-NEXT:                     (ascription basics.silt:15:14
+-- CHECK-NEXT:                       (identifierList basics.silt:15:14
+-- CHECK-NEXT:                         (identifier "a" basics.silt:15:14))
+-- CHECK-NEXT:                       (colon basics.silt:15:16)
+-- CHECK-NEXT:                       (applicationExpr basics.silt:15:18
+-- CHECK-NEXT:                         (basicExprList basics.silt:15:18
+-- CHECK-NEXT:                           (namedBasicExpr basics.silt:15:18
+-- CHECK-NEXT:                             (qualifiedName basics.silt:15:18
+-- CHECK-NEXT:                               (qualifiedNamePiece basics.silt:15:18
+-- CHECK-NEXT:                                 (identifier "A" basics.silt:15:18)))))))
+-- CHECK-NEXT:                     (rightParen basics.silt:15:19)))
+-- CHECK-NEXT:                 (arrow basics.silt:15:21)
+-- CHECK-NEXT:                 (applicationExpr basics.silt:15:24
+-- CHECK-NEXT:                   (basicExprList basics.silt:15:24
+-- CHECK-NEXT:                     (namedBasicExpr basics.silt:15:24
+-- CHECK-NEXT:                       (qualifiedName basics.silt:15:24
+-- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:15:24
+-- CHECK-NEXT:                           (identifier "C" basics.silt:15:24))))
+-- CHECK-NEXT:                     (namedBasicExpr basics.silt:15:26
+-- CHECK-NEXT:                       (qualifiedName basics.silt:15:26
+-- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:15:26
+-- CHECK-NEXT:                           (identifier "a" basics.silt:15:26))))
+-- CHECK-NEXT:                     (parenthesizedExpr basics.silt:15:28
+-- CHECK-NEXT:                       (leftParen basics.silt:15:28)
+-- CHECK-NEXT:                       (applicationExpr basics.silt:15:29
+-- CHECK-NEXT:                         (basicExprList basics.silt:15:29
+-- CHECK-NEXT:                           (namedBasicExpr basics.silt:15:29
+-- CHECK-NEXT:                             (qualifiedName basics.silt:15:29
+-- CHECK-NEXT:                               (qualifiedNamePiece basics.silt:15:29
+-- CHECK-NEXT:                                 (identifier "g" basics.silt:15:29))))
+-- CHECK-NEXT:                           (namedBasicExpr basics.silt:15:31
+-- CHECK-NEXT:                             (qualifiedName basics.silt:15:31
+-- CHECK-NEXT:                               (qualifiedNamePiece basics.silt:15:31
+-- CHECK-NEXT:                                 (identifier "a" basics.silt:15:31))))))
+-- CHECK-NEXT:                       (rightParen basics.silt:15:32))))))))))
+-- CHECK-NEXT:     (normalFunctionClauseDecl basics.silt:16:0
+-- CHECK-NEXT:       (basicExprList basics.silt:16:0
+-- CHECK-NEXT:         (namedBasicExpr basics.silt:16:0
+-- CHECK-NEXT:           (qualifiedName basics.silt:16:0
+-- CHECK-NEXT:             (qualifiedNamePiece basics.silt:16:0
+-- CHECK-NEXT:               (identifier "f" basics.silt:16:0))))
+-- CHECK-NEXT:         (namedBasicExpr basics.silt:16:2
+-- CHECK-NEXT:           (qualifiedName basics.silt:16:2
+-- CHECK-NEXT:             (qualifiedNamePiece basics.silt:16:2
+-- CHECK-NEXT:               (identifier "o" basics.silt:16:2))))
+-- CHECK-NEXT:         (namedBasicExpr basics.silt:16:4
+-- CHECK-NEXT:           (qualifiedName basics.silt:16:4
+-- CHECK-NEXT:             (qualifiedNamePiece basics.silt:16:4
+-- CHECK-NEXT:               (identifier "g" basics.silt:16:4)))))
+-- CHECK-NEXT:       (equals basics.silt:16:6)
+-- CHECK-NEXT:       (lambdaExpr basics.silt:16:8
+-- CHECK-NEXT:         (forwardSlash basics.silt:16:8)
+-- CHECK-NEXT:         (bindingList basics.silt:16:10
+-- CHECK-NEXT:           (namedBinding basics.silt:16:10
+-- CHECK-NEXT:             (qualifiedName basics.silt:16:10
+-- CHECK-NEXT:               (qualifiedNamePiece basics.silt:16:10
+-- CHECK-NEXT:                 (identifier "a" basics.silt:16:10)))))
+-- CHECK-NEXT:         (arrow basics.silt:16:12)
+-- CHECK-NEXT:         (applicationExpr basics.silt:16:15
+-- CHECK-NEXT:           (basicExprList basics.silt:16:15
+-- CHECK-NEXT:             (namedBasicExpr basics.silt:16:15
+-- CHECK-NEXT:               (qualifiedName basics.silt:16:15
+-- CHECK-NEXT:                 (qualifiedNamePiece basics.silt:16:15
+-- CHECK-NEXT:                   (identifier "f" basics.silt:16:15))))
+-- CHECK-NEXT:             (parenthesizedExpr basics.silt:16:17
+-- CHECK-NEXT:               (leftParen basics.silt:16:17)
+-- CHECK-NEXT:               (applicationExpr basics.silt:16:18
+-- CHECK-NEXT:                 (basicExprList basics.silt:16:18
+-- CHECK-NEXT:                   (namedBasicExpr basics.silt:16:18
+-- CHECK-NEXT:                     (qualifiedName basics.silt:16:18
+-- CHECK-NEXT:                       (qualifiedNamePiece basics.silt:16:18
+-- CHECK-NEXT:                         (identifier "g" basics.silt:16:18))))
+-- CHECK-NEXT:                   (namedBasicExpr basics.silt:16:20
+-- CHECK-NEXT:                     (qualifiedName basics.silt:16:20
+-- CHECK-NEXT:                       (qualifiedNamePiece basics.silt:16:20
+-- CHECK-NEXT:                         (identifier "a" basics.silt:16:20))))))
+-- CHECK-NEXT:               (rightParen basics.silt:16:21))))))))

--- a/Tests/SyntaxTests/Resources/basics.silt.shined
+++ b/Tests/SyntaxTests/Resources/basics.silt.shined
@@ -8,7 +8,7 @@
 -- CHECK-NEXT: ((x : A) (y : B) -> C x y) -> ((y : B) (x : A) -> C x y);
 -- CHECK-NEXT: flip f = \ y x -> f x y;
 
--- CHECK: _ o _ : forall {i j k : Level}
+-- CHECK: _o_ : forall {i j k : Level}
 -- CHECK-NEXT: {A : Type i}{B : A -> Type j}{C : (a : A) -> B a -> Type k} ->
 -- CHECK-NEXT: (f : {a : A}(b : B a) -> C a b) ->
 -- CHECK-NEXT: (g : (a : A) -> B a) ->

--- a/Tests/SyntaxTests/Resources/basics.silt.syntax
+++ b/Tests/SyntaxTests/Resources/basics.silt.syntax
@@ -15,7 +15,7 @@ _ o _ : forall {i j k : Level}
                (a : A) -> C a (g a)
 f o g = \ a -> f (g a)
 
--- CHECK: Token: moduleKeyword
+-- CHECK:      Token: moduleKeyword
 -- CHECK-NEXT:   Leading Trivia:
 -- CHECK-NEXT:     comment("-- A type")
 -- CHECK-NEXT:     newlines(1)
@@ -397,17 +397,9 @@ f o g = \ a -> f (g a)
 -- CHECK-NEXT: Token: identifier("y")
 -- CHECK-NEXT:   Leading Trivia:
 -- CHECK-NEXT:   Trailing Trivia:
--- CHECK-NEXT: Token: underscore
+-- CHECK-NEXT: Token: identifier("_o_")
 -- CHECK-NEXT:   Leading Trivia:
 -- CHECK-NEXT:     newlines(2)
--- CHECK-NEXT:   Trailing Trivia:
--- CHECK-NEXT:     spaces(1)
--- CHECK-NEXT: Token: identifier("o")
--- CHECK-NEXT:   Leading Trivia:
--- CHECK-NEXT:   Trailing Trivia:
--- CHECK-NEXT:     spaces(1)
--- CHECK-NEXT: Token: underscore
--- CHECK-NEXT:   Leading Trivia:
 -- CHECK-NEXT:   Trailing Trivia:
 -- CHECK-NEXT:     spaces(1)
 -- CHECK-NEXT: Token: colon
@@ -446,7 +438,7 @@ f o g = \ a -> f (g a)
 -- CHECK-NEXT: Token: leftBrace
 -- CHECK-NEXT:   Leading Trivia:
 -- CHECK-NEXT:     newlines(1)
--- CHECK-NEXT:     spaces(15)
+-- CHECK-NEXT:     spaces(13)
 -- CHECK-NEXT:   Trailing Trivia:
 -- CHECK-NEXT: Token: identifier("A")
 -- CHECK-NEXT:   Leading Trivia:
@@ -557,7 +549,7 @@ f o g = \ a -> f (g a)
 -- CHECK-NEXT: Token: leftParen
 -- CHECK-NEXT:   Leading Trivia:
 -- CHECK-NEXT:     newlines(1)
--- CHECK-NEXT:     spaces(15)
+-- CHECK-NEXT:     spaces(13)
 -- CHECK-NEXT:   Trailing Trivia:
 -- CHECK-NEXT: Token: identifier("f")
 -- CHECK-NEXT:   Leading Trivia:
@@ -631,7 +623,7 @@ f o g = \ a -> f (g a)
 -- CHECK-NEXT: Token: leftParen
 -- CHECK-NEXT:   Leading Trivia:
 -- CHECK-NEXT:     newlines(1)
--- CHECK-NEXT:     spaces(15)
+-- CHECK-NEXT:     spaces(13)
 -- CHECK-NEXT:   Trailing Trivia:
 -- CHECK-NEXT: Token: identifier("g")
 -- CHECK-NEXT:   Leading Trivia:
@@ -680,7 +672,7 @@ f o g = \ a -> f (g a)
 -- CHECK-NEXT: Token: leftParen
 -- CHECK-NEXT:   Leading Trivia:
 -- CHECK-NEXT:     newlines(1)
--- CHECK-NEXT:     spaces(15)
+-- CHECK-NEXT:     spaces(13)
 -- CHECK-NEXT:   Trailing Trivia:
 -- CHECK-NEXT: Token: identifier("a")
 -- CHECK-NEXT:   Leading Trivia:
@@ -772,4 +764,3 @@ f o g = \ a -> f (g a)
 -- CHECK-NEXT:   Leading Trivia:
 -- CHECK-NEXT:     newlines(2)
 -- CHECK-NEXT:   Trailing Trivia:
-

--- a/Tests/SyntaxTests/Resources/datatypes.silt.ast
+++ b/Tests/SyntaxTests/Resources/datatypes.silt.ast
@@ -1,4 +1,4 @@
--- CHECK: (moduleDecl datatypes.silt:1:1
+-- CHECK:      (moduleDecl datatypes.silt:1:1
 -- CHECK-NEXT:   (moduleKeyword datatypes.silt:1:1)
 -- CHECK-NEXT:   (qualifiedName datatypes.silt:1:8
 -- CHECK-NEXT:     (qualifiedNamePiece datatypes.silt:1:8
@@ -12,8 +12,10 @@
 -- CHECK-NEXT:       (typedParameterList)
 -- CHECK-NEXT:       (typeIndices datatypes.silt:3:7
 -- CHECK-NEXT:         (colon datatypes.silt:3:7)
--- CHECK-NEXT:         (typeBasicExpr datatypes.silt:3:9
--- CHECK-NEXT:           (typeKeyword datatypes.silt:3:9)))
+-- CHECK-NEXT:         (applicationExpr datatypes.silt:3:9
+-- CHECK-NEXT:           (basicExprList datatypes.silt:3:9
+-- CHECK-NEXT:             (typeBasicExpr datatypes.silt:3:9
+-- CHECK-NEXT:               (typeKeyword datatypes.silt:3:9)))))
 -- CHECK-NEXT:       (whereKeyword datatypes.silt:3:14)
 -- CHECK-NEXT:       (constructorList datatypes.silt:4:2
 -- CHECK-NEXT:         (constructorDecl datatypes.silt:4:2
@@ -22,25 +24,29 @@
 -- CHECK-NEXT:             (identifierList datatypes.silt:4:4
 -- CHECK-NEXT:               (identifier "zero" datatypes.silt:4:4))
 -- CHECK-NEXT:             (colon datatypes.silt:4:9)
--- CHECK-NEXT:             (namedBasicExpr datatypes.silt:4:11
--- CHECK-NEXT:               (qualifiedName datatypes.silt:4:11
--- CHECK-NEXT:                 (qualifiedNamePiece datatypes.silt:4:11
--- CHECK-NEXT:                   (identifier "N" datatypes.silt:4:11))))))
+-- CHECK-NEXT:             (applicationExpr datatypes.silt:4:11
+-- CHECK-NEXT:               (basicExprList datatypes.silt:4:11
+-- CHECK-NEXT:                 (namedBasicExpr datatypes.silt:4:11
+-- CHECK-NEXT:                   (qualifiedName datatypes.silt:4:11
+-- CHECK-NEXT:                     (qualifiedNamePiece datatypes.silt:4:11
+-- CHECK-NEXT:                       (identifier "N" datatypes.silt:4:11))))))))
 -- CHECK-NEXT:         (constructorDecl datatypes.silt:5:2
 -- CHECK-NEXT:           (pipe datatypes.silt:5:2)
 -- CHECK-NEXT:           (ascription datatypes.silt:5:4
 -- CHECK-NEXT:             (identifierList datatypes.silt:5:4
 -- CHECK-NEXT:               (identifier "succ" datatypes.silt:5:4))
 -- CHECK-NEXT:             (colon datatypes.silt:5:9)
--- CHECK-NEXT:             (basicExprListArrowExpr datatypes.silt:5:11
+-- CHECK-NEXT:             (applicationExpr datatypes.silt:5:11
 -- CHECK-NEXT:               (basicExprList datatypes.silt:5:11
 -- CHECK-NEXT:                 (namedBasicExpr datatypes.silt:5:11
 -- CHECK-NEXT:                   (qualifiedName datatypes.silt:5:11
 -- CHECK-NEXT:                     (qualifiedNamePiece datatypes.silt:5:11
--- CHECK-NEXT:                       (identifier "N" datatypes.silt:5:11)))))
--- CHECK-NEXT:               (arrow datatypes.silt:5:13)
--- CHECK-NEXT:               (namedBasicExpr datatypes.silt:5:16
--- CHECK-NEXT:                 (qualifiedName datatypes.silt:5:16
--- CHECK-NEXT:                   (qualifiedNamePiece datatypes.silt:5:16
--- CHECK-NEXT:                     (identifier "N" datatypes.silt:5:16)))))))))))
-
+-- CHECK-NEXT:                       (identifier "N" datatypes.silt:5:11))))
+-- CHECK-NEXT:                 (namedBasicExpr datatypes.silt:5:13
+-- CHECK-NEXT:                   (qualifiedName datatypes.silt:5:13
+-- CHECK-NEXT:                     (qualifiedNamePiece datatypes.silt:5:13
+-- CHECK-NEXT:                       (arrow datatypes.silt:5:13))))
+-- CHECK-NEXT:                 (namedBasicExpr datatypes.silt:5:16
+-- CHECK-NEXT:                   (qualifiedName datatypes.silt:5:16
+-- CHECK-NEXT:                     (qualifiedNamePiece datatypes.silt:5:16
+-- CHECK-NEXT:                       (identifier "N" datatypes.silt:5:16))))))))))))

--- a/Tests/SyntaxTests/SyntaxTestRunner.swift
+++ b/Tests/SyntaxTests/SyntaxTestRunner.swift
@@ -88,7 +88,7 @@ class SyntaxTestRunner: XCTestCase {
 
       let syntaxFile = file.appendingPathExtension("syntax").path
       if FileManager.default.fileExists(atPath: syntaxFile) {
-        XCTAssert(fileCheckOutput(against: syntaxFile) {
+        XCTAssert(fileCheckOutput(against: .filePath(syntaxFile)) {
           describe(siltFile, at: file.absoluteString, by: .describingTokens)
         }, "failed while dumping syntax file \(syntaxFile)")
       } else {
@@ -97,7 +97,7 @@ class SyntaxTestRunner: XCTestCase {
 
       let astFile = file.appendingPathExtension("ast").path
       if FileManager.default.fileExists(atPath: astFile) {
-        XCTAssert(fileCheckOutput(against: astFile) {
+        XCTAssert(fileCheckOutput(against: .filePath(astFile)) {
           describe(siltFile, at: file.absoluteString, by: .dumpingParse)
         }, "failed while dumping AST file \(astFile)")
       } else {
@@ -106,7 +106,7 @@ class SyntaxTestRunner: XCTestCase {
 
       if FileManager.default.fileExists(atPath: astFile) {
         let shineFile = file.appendingPathExtension("shined").path
-        XCTAssert(fileCheckOutput(against: shineFile) {
+        XCTAssert(fileCheckOutput(against: .filePath(shineFile)) {
           describe(siltFile, at: file.absoluteString, by: .dumpingShined)
         }, "failed while dumping Shined file \(shineFile)")
       } else {

--- a/Tests/SyntaxTests/SyntaxTestRunner.swift
+++ b/Tests/SyntaxTests/SyntaxTestRunner.swift
@@ -21,6 +21,50 @@ enum Action {
 }
 
 class SyntaxTestRunner: XCTestCase {
+  var engine: DiagnosticEngine!
+
+  /// A diagnostic consumer that emits an XCTFail with the serialized
+  /// diagnostic whenever a diagnostic is emitted.
+  class XCTestFailureConsumer: DiagnosticConsumer {
+    /// A reference type that exists to keep alive a String.
+    class StreamBuffer: TextOutputStream {
+      var value = ""
+      func write(_ string: String) {
+        value += string
+      }
+      func clear() {
+        value = ""
+      }
+    }
+
+    /// A buffer for each diagnostic.
+    var scratch = StreamBuffer()
+
+    /// A printing diagnostic consumer that will serialize diagnostics
+    /// to a string.
+    let printer: PrintingDiagnosticConsumer<StreamBuffer>
+
+    init() {
+      printer = .init(stream: &scratch)
+    }
+
+    /// XCTFails with the serialized version of the diagnostic provided.
+    func handle(_ diagnostic: Diagnostic) {
+      scratch.clear()
+      printer.handle(diagnostic)
+      XCTFail(scratch.value)
+    }
+
+    func finalize() {
+      // Do nothing
+    }
+  }
+
+  override func setUp() {
+    engine = DiagnosticEngine()
+    engine.register(XCTestFailureConsumer())
+  }
+
   func testSyntax() {
     let filesURL = URL(fileURLWithPath: #file)
       .deletingLastPathComponent()
@@ -89,7 +133,7 @@ class SyntaxTestRunner: XCTestCase {
     case .describingTokens:
       TokenDescriber.describe(tokens, to: &stdoutStream)
     case .dumpingParse:
-      let parser = Parser(tokens: layoutTokens)
+      let parser = Parser(diagnosticEngine: engine, tokens: layoutTokens)
       guard let tlm = parser.parseTopLevelModule() else {
         XCTFail("Parsing top level module failed!")
         return


### PR DESCRIPTION
Builds on #24 by splitting functions into clause decls and ascriptions and parsing them sans backtracking.