### PR TITLE
Improve diagnostic message for missing module

### DIFF
--- a/Sources/Crust/Parser.swift
+++ b/Sources/Crust/Parser.swift
@@ -27,9 +27,14 @@ extension Diagnostic.Message {
   }
   static let unexpectedEOF =
     Diagnostic.Message(.error, "unexpected end-of-file reached")
+
   static func expected(_ name: String) -> Diagnostic.Message {
     return Diagnostic.Message(.error, "expected \(name)")
   }
+
+  static let expectedTopLevelModule =
+    Diagnostic.Message(
+      .error, "missing required top level module")
 
   static let expectedNameInFuncDecl =
     Diagnostic.Message(
@@ -119,6 +124,9 @@ public class Parser {
 extension Parser {
   public func parseTopLevelModule() -> ModuleDeclSyntax? {
     do {
+      guard peek() == .moduleKeyword else {
+        throw engine.diagnose(.expectedTopLevelModule, node: currentToken)
+      }
       let module = try parseModule()
       _ = try consume(.eof)
       return module

--- a/Tests/DiagnosticTests/Resources/no-module.silt
+++ b/Tests/DiagnosticTests/Resources/no-module.silt
@@ -1,4 +1,4 @@
 id : ∀ {A: Type} A -> A
--- expected-error@-1 {{unexpected token '{{.*}}'}}
+-- expected-error@-1 {{missing required top level module}}
 id x = x
 


### PR DESCRIPTION
### What's in this pull request?

Improves the error message surrounding an undefined top-level module in a file.

Resolves: Issue #36

### Why merge this pull request?
N/A

### What's worth discussing about this pull request?
Implementation could be a little naive. Just checks if the `currentToken.tokenKind` is a `moduleKeyword` when calling `Parser.parseModule`. I'm unsure if `parseModule` will be called in any contexts other than `Parser.parseTopLevelModule`.

### What downsides are there to merging this pull request?
N/A
