### PR TITLE
Add git attributes to highlight Silt code as Agda

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.silt linguist-language=Agda

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,7 @@
+# Highlight Silt as Agda
 *.silt linguist-language=Agda
+
+# Generated files
+Sources/Lithosphere/SyntaxNodes.swift linguist-generated=true
+Sources/Lithosphere/SyntaxKind.swift linguist-generated=true
+Sources/Lithosphere/TokenKind.swift linguist-generated=true


### PR DESCRIPTION
### What's in this pull request?

GitHub's Linguist allows you to override the highlighting of different file types, so let's use this to do some basic silt highlighting.

### Why merge this pull request?

It makes code reviews of Silt code muuuuuch nicer.

### What's worth discussing about this pull request?

Is Agda the closest approximation here?

### What downsides are there to merging this pull request?

None.
