### PR TITLE
[RFC] Initial stab at pass structure

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
       dependencies: ["Drill", "Symbolic", "SwiftShell", "CommandLine"]),
     .target(
       name: "lite",
-      dependencies: ["LiteSupport"]),
+      dependencies: ["LiteSupport", "silt"]),
     .target(
       name: "Moho",
       dependencies: ["Lithosphere", "Crust"]),

--- a/Sources/Drill/DiagnosticGatePass.swift
+++ b/Sources/Drill/DiagnosticGatePass.swift
@@ -1,0 +1,39 @@
+/// DiagnosticGatePass.swift
+///
+/// Copyright 2017, The Silt Language Project.
+///
+/// This project is released under the MIT license, a copy of which is
+/// available in the repository.
+
+import Foundation
+import Lithosphere
+
+/// A DiagnosticGatePass is a pass that wraps another pass and throws away its
+/// resulting value if any diagnostics were emitted.
+/// This is useful for passes that only communicate failure via diagnostics,
+/// like semantic analysis passes.
+struct DiagnosticGatePass<PassTy: PassProtocol>: PassProtocol {
+  /// The input of the underlying pass type.
+  typealias Input = PassTy.Input
+
+  /// The output of the underlying pass type.
+  typealias Output = PassTy.Output
+
+  var name: String {
+    return pass.name
+  }
+  let pass: PassTy
+
+  /// Creates a DiagnosticGatePass that wraps the provided pass.
+  /// - parameter pass: The pass to gate on diagnostic emission.
+  init(_ pass: PassTy) {
+    self.pass = pass
+  }
+
+  /// Runs the underlying pass, but doesn't forward the value if the
+  /// Diagnostic Engine registered an error.
+  func run(_ input: Input, in context: PassContext) -> Output? {
+    let output = pass.run(input, in: context)
+    return context.engine.hasErrors() ? nil : output
+  }
+}

--- a/Sources/Drill/Invocation.swift
+++ b/Sources/Drill/Invocation.swift
@@ -67,9 +67,9 @@ public struct Invocation {
     }
 
     let shineFile = Passes.lex |> Passes.shine
-    let parseFile = Passes.lex |> Passes.shine |> Passes.parse
+    let parseFile = shineFile |> Passes.parse
     let scopeCheckFile =
-      Passes.lex |> Passes.shine |> Passes.parse |> Passes.scopeCheck
+      parseFile |> Passes.scopeCheck
 
     for path in sourceFiles {
       let url = URL(fileURLWithPath: path)

--- a/Sources/Drill/Invocation.swift
+++ b/Sources/Drill/Invocation.swift
@@ -36,6 +36,9 @@ public struct Invocation {
   ///   - url: The URL of the file to read.
   ///   - pass: The pass to run before verifying.
   ///   - context: The context in which to run the pass.
+  /// - note: The pass this function returns will never return `nil`, it will
+  ///         return `true` if the verifier produced errors and `false`
+  ///         otherwise. It is safe to force-unwrap.
   private func makeVerifyPass<PassTy: PassProtocol>(url: URL, pass: PassTy,
     context: PassContext) -> Pass<PassTy.Input, HadErrors> {
     return Pass(name: "Diagnostic Verification") { input, ctx in
@@ -118,10 +121,10 @@ public struct Invocation {
         switch verification {
         case .parse:
           return run(makeVerifyPass(url: url, pass: parseFile,
-                                    context: context)) ?? true
+                                    context: context))!
         case .scopes:
           return run(makeVerifyPass(url: url, pass: scopeCheckFile,
-                                    context: context)) ?? true
+                                    context: context))!
         }
       }
     }

--- a/Sources/Drill/Invocation.swift
+++ b/Sources/Drill/Invocation.swift
@@ -125,20 +125,18 @@ public struct Invocation {
           SyntaxDumper(stream: &stderrStream).dump(module)
         })
       case .dump(.scopes):
-        let layoutTokens = layout(tokens)
-        let parser = Parser(diagnosticEngine: engine, tokens: layoutTokens)
-        let module = parser.parseTopLevelModule()!
-        let binder = NameBinding(topLevel: module, engine: engine)
-        print(binder.performScopeCheck(topLevel: module))
+        run(scopeCheckPass |> Pass(name: "Dump Scopes") { module, _ in
+          print(module)
+        })
       case .verify(let verification):
         engine.unregister(printingConsumerToken)
         switch verification {
         case .parse:
           return run(makeVerifyPass(url: url, pass: parsePass,
-                                    context: context))
+                                    context: context)) ?? true
         case .scopes:
           return run(makeVerifyPass(url: url, pass: scopeCheckPass,
-                                    context: context))
+                                    context: context)) ?? true
         }
       }
     }

--- a/Sources/Drill/Options.swift
+++ b/Sources/Drill/Options.swift
@@ -45,11 +45,13 @@ public enum Mode {
 }
 
 public struct Options {
-    public let mode: Mode
-    public let colorsEnabled: Bool
+  public let mode: Mode
+  public let colorsEnabled: Bool
+  public let shouldPrintTiming: Bool
 
-    public init(mode: Mode, colorsEnabled: Bool) {
-        self.mode = mode
-        self.colorsEnabled = colorsEnabled
-    }
+  public init(mode: Mode, colorsEnabled: Bool, shouldPrintTiming: Bool) {
+    self.mode = mode
+    self.colorsEnabled = colorsEnabled
+    self.shouldPrintTiming = shouldPrintTiming
+  }
 }

--- a/Sources/Drill/Pass.swift
+++ b/Sources/Drill/Pass.swift
@@ -38,7 +38,9 @@ struct Pass<In, Out>: PassProtocol {
   }
 
   func run(_ input: In, in context: PassContext) -> Out? {
-    return actions(input, context)
+    return context.timer.measure(pass: name) {
+      actions(input, context)
+    }
   }
 }
 

--- a/Sources/Drill/Pass.swift
+++ b/Sources/Drill/Pass.swift
@@ -44,10 +44,10 @@ struct Pass<In, Out>: PassProtocol {
   }
 }
 
-struct JoinedPass<Input, Intermediate, Output,
+struct JoinedPass<Input, Output,
                   PassA: PassProtocol, PassB: PassProtocol>: PassProtocol
-   where PassA.Input == Input, PassA.Output == Intermediate,
-         PassB.Input == Intermediate, PassB.Output == Output {
+   where PassA.Input == Input, PassA.Output == PassB.Input,
+         PassB.Output == Output {
   let name = "JoinedPass"
   let passA: PassA
   let passB: PassB
@@ -59,8 +59,9 @@ struct JoinedPass<Input, Intermediate, Output,
   }
 }
 
-func |<Input, Intermediate, Output, PassA: PassProtocol, PassB: PassProtocol>(
-  passA: PassA, passB: PassB) -> JoinedPass<Input, Intermediate, Output,
-                                            PassA, PassB> {
+infix operator |> : AdditionPrecedence
+
+func |><Input, Output, PassA: PassProtocol, PassB: PassProtocol>(
+  passA: PassA, passB: PassB) -> JoinedPass<Input, Output, PassA, PassB> {
   return JoinedPass(passA: passA, passB: passB)
 }

--- a/Sources/Drill/Pass.swift
+++ b/Sources/Drill/Pass.swift
@@ -59,6 +59,27 @@ struct PassComposition<Input, Output,
   }
 }
 
+struct DiagnosticGatePass<PassTy: PassProtocol>: PassProtocol {
+  typealias Input = PassTy.Input
+  typealias Output = PassTy.Output
+
+  var name: String {
+    return pass.name
+  }
+  let pass: PassTy
+
+  init(_ pass: PassTy) {
+    self.pass = pass
+  }
+
+  /// Runs the underlying pass, but doesn't forward the value if the
+  /// Diagnostic Engine registered an error.
+  func run(_ input: Input, in context: PassContext) -> Output? {
+    let output = pass.run(input, in: context)
+    return context.engine.hasErrors() ? nil : output
+  }
+}
+
 infix operator |> : AdditionPrecedence
 
 func |><Input, Output, PassA: PassProtocol, PassB: PassProtocol>(

--- a/Sources/Drill/Pass.swift
+++ b/Sources/Drill/Pass.swift
@@ -8,6 +8,8 @@
 import Foundation
 import Lithosphere
 
+/// A class that's passed to invocations of each pass. It contains a timer
+/// and diagnostic engine that each pass can make use of.
 class PassContext {
   let timer = PassTimer()
   let engine: DiagnosticEngine
@@ -17,26 +19,50 @@ class PassContext {
   }
 }
 
+/// Defines the set of behaviors of a compiler pass. Passes can be thought of
+/// as functions from Input to Output, but which execute in a context.
 protocol PassProtocol {
+  /// The type of values that this pass consumes.
   associatedtype Input
+
+  /// The type of output this pass transforms the Input into.
   associatedtype Output
 
+  /// The display name of this pass (used for pass timing).
   var name: String { get }
+
+  /// Runs this pass with the provided input in the provided context.
+  /// - parameters:
+  ///   - input: The input to this pass (usually output from a previous pass).
+  ///   - context: The pass context this pass will be executed in.
+  /// - returns: An optional transformed value based on the input. If this
+  ///            pass failed, it should return `nil` from this method.
   func run(_ input: Input, in context: PassContext) -> Output?
 }
 
+/// A Pass is the most common currency for compiler passes. It wraps a function
+/// with the same signature as `PassProtocol`'s `run` method, and is responsible
+/// for invoking the pass timer before executing its actions.
 struct Pass<In, Out>: PassProtocol {
+  /// The input is generic to each pass.
   typealias Input = In
+
+  /// The output is generic to each pass.
   typealias Output = Out
 
   let name: String
   let actions: (Input, PassContext) -> Output?
 
+  /// Creates a new `Pass` with the given name and actions.
+  /// - parameters:
+  ///   - name: A displayable name for this pass.
+  ///   - actions: A function that represents the body of the pass.
   init(name: String, actions: @escaping (Input, PassContext) -> Output?) {
     self.name = name
     self.actions = actions
   }
 
+  /// Runs the provided actions, passing along the input and context.
   func run(_ input: In, in context: PassContext) -> Out? {
     return context.timer.measure(pass: name) {
       actions(input, context)
@@ -44,14 +70,29 @@ struct Pass<In, Out>: PassProtocol {
   }
 }
 
-struct PassComposition<Input, Output,
-                       PassA: PassProtocol, PassB: PassProtocol>: PassProtocol
+/// A PassComposition, analogous to function composition, executes one pass
+/// and pipes its output to the second pass. It converts two passes `(A) -> B`
+/// and `(B) -> C` into one pass, `(A) -> C`.
+struct PassComposition<Input, Output, PassA: PassProtocol,
+                       PassB: PassProtocol>: PassProtocol
    where PassA.Input == Input, PassA.Output == PassB.Input,
          PassB.Output == Output {
   let name = "PassComposition"
+
+  /// The first pass to execute.
   let passA: PassA
+
+  /// The second pass to execute.
   let passB: PassB
 
+
+  /// Runs the first pass and, if it returned a non-`nil` value, passes
+  /// the value to the second pass and returns that value.
+  ///
+  /// - Parameters:
+  ///   - input: The input to the first pass.
+  ///   - context: The context in which to execute the passes.
+  /// - Returns: The output of the second pass, or `nil` if either pass failed.
   func run(_ input: Input, in context: PassContext) -> Output? {
     return passA.run(input, in: context).flatMap {
       passB.run($0, in: context)
@@ -59,8 +100,15 @@ struct PassComposition<Input, Output,
   }
 }
 
+/// A DiagnosticGatePass is a pass that wraps another pass and throws away its
+/// resulting value if any diagnostics were emitted.
+/// This is useful for passes that only communicate failure via diagnostics,
+/// like semantic analysis passes.
 struct DiagnosticGatePass<PassTy: PassProtocol>: PassProtocol {
+  /// The input of the underlying pass type.
   typealias Input = PassTy.Input
+
+  /// The output of the underlying pass type.
   typealias Output = PassTy.Output
 
   var name: String {
@@ -68,6 +116,8 @@ struct DiagnosticGatePass<PassTy: PassProtocol>: PassProtocol {
   }
   let pass: PassTy
 
+  /// Creates a DiagnosticGatePass that wraps the provided pass.
+  /// - parameter pass: The pass to gate on diagnostic emission.
   init(_ pass: PassTy) {
     self.pass = pass
   }
@@ -80,8 +130,16 @@ struct DiagnosticGatePass<PassTy: PassProtocol>: PassProtocol {
   }
 }
 
+/// An operator that represents a composition of passes.
 infix operator |> : AdditionPrecedence
 
+
+/// Composes two passes together into one pass.
+///
+/// - Parameters:
+///   - passA: The first pass to run.
+///   - passB: The second pass to run if the first succeeds.
+/// - Returns: The output of the second pass, or `nil` if either pass failed.
 func |><Input, Output, PassA: PassProtocol, PassB: PassProtocol>(
   passA: PassA, passB: PassB) -> PassComposition<Input, Output, PassA, PassB> {
   return PassComposition(passA: passA, passB: passB)

--- a/Sources/Drill/Pass.swift
+++ b/Sources/Drill/Pass.swift
@@ -73,10 +73,8 @@ struct Pass<In, Out>: PassProtocol {
 /// A PassComposition, analogous to function composition, executes one pass
 /// and pipes its output to the second pass. It converts two passes `(A) -> B`
 /// and `(B) -> C` into one pass, `(A) -> C`.
-struct PassComposition<Input, Output, PassA: PassProtocol,
-                       PassB: PassProtocol>: PassProtocol
-   where PassA.Input == Input, PassA.Output == PassB.Input,
-         PassB.Output == Output {
+struct PassComposition<PassA: PassProtocol, PassB: PassProtocol>: PassProtocol
+   where PassA.Output == PassB.Input {
   let name = "PassComposition"
 
   /// The first pass to execute.
@@ -93,7 +91,7 @@ struct PassComposition<Input, Output, PassA: PassProtocol,
   ///   - input: The input to the first pass.
   ///   - context: The context in which to execute the passes.
   /// - Returns: The output of the second pass, or `nil` if either pass failed.
-  func run(_ input: Input, in context: PassContext) -> Output? {
+  func run(_ input: PassA.Input, in context: PassContext) -> PassB.Output? {
     return passA.run(input, in: context).flatMap {
       passB.run($0, in: context)
     }
@@ -140,7 +138,7 @@ infix operator |> : AdditionPrecedence
 ///   - passA: The first pass to run.
 ///   - passB: The second pass to run if the first succeeds.
 /// - Returns: The output of the second pass, or `nil` if either pass failed.
-func |><Input, Output, PassA: PassProtocol, PassB: PassProtocol>(
-  passA: PassA, passB: PassB) -> PassComposition<Input, Output, PassA, PassB> {
+func |><PassA: PassProtocol, PassB: PassProtocol>(
+  passA: PassA, passB: PassB) -> PassComposition<PassA, PassB> {
   return PassComposition(passA: passA, passB: passB)
 }

--- a/Sources/Drill/Pass.swift
+++ b/Sources/Drill/Pass.swift
@@ -44,11 +44,11 @@ struct Pass<In, Out>: PassProtocol {
   }
 }
 
-struct JoinedPass<Input, Output,
-                  PassA: PassProtocol, PassB: PassProtocol>: PassProtocol
+struct PassComposition<Input, Output,
+                       PassA: PassProtocol, PassB: PassProtocol>: PassProtocol
    where PassA.Input == Input, PassA.Output == PassB.Input,
          PassB.Output == Output {
-  let name = "JoinedPass"
+  let name = "PassComposition"
   let passA: PassA
   let passB: PassB
 
@@ -62,6 +62,6 @@ struct JoinedPass<Input, Output,
 infix operator |> : AdditionPrecedence
 
 func |><Input, Output, PassA: PassProtocol, PassB: PassProtocol>(
-  passA: PassA, passB: PassB) -> JoinedPass<Input, Output, PassA, PassB> {
-  return JoinedPass(passA: passA, passB: passB)
+  passA: PassA, passB: PassB) -> PassComposition<Input, Output, PassA, PassB> {
+  return PassComposition(passA: passA, passB: passB)
 }

--- a/Sources/Drill/Pass.swift
+++ b/Sources/Drill/Pass.swift
@@ -1,0 +1,64 @@
+/// Pass.swift
+///
+/// Copyright 2017, The Silt Language Project.
+///
+/// This project is released under the MIT license, a copy of which is
+/// available in the repository.
+
+import Foundation
+import Lithosphere
+
+class PassContext {
+  let timer = PassTimer()
+  let engine: DiagnosticEngine
+
+  init(engine: DiagnosticEngine) {
+    self.engine = engine
+  }
+}
+
+protocol PassProtocol {
+  associatedtype Input
+  associatedtype Output
+
+  var name: String { get }
+  func run(_ input: Input, in context: PassContext) -> Output?
+}
+
+struct Pass<In, Out>: PassProtocol {
+  typealias Input = In
+  typealias Output = Out
+
+  let name: String
+  let actions: (Input, PassContext) -> Output?
+
+  init(name: String, actions: @escaping (Input, PassContext) -> Output?) {
+    self.name = name
+    self.actions = actions
+  }
+
+  func run(_ input: In, in context: PassContext) -> Out? {
+    return actions(input, context)
+  }
+}
+
+struct JoinedPass<Input, Intermediate, Output,
+                  PassA: PassProtocol, PassB: PassProtocol>: PassProtocol
+   where PassA.Input == Input, PassA.Output == Intermediate,
+         PassB.Input == Intermediate, PassB.Output == Output {
+  let name = "JoinedPass"
+  let passA: PassA
+  let passB: PassB
+
+  func run(_ input: Input, in context: PassContext) -> Output? {
+    return passA.run(input, in: context).flatMap {
+      passB.run($0, in: context)
+    }
+  }
+}
+
+func |<Input, Intermediate, Output, PassA: PassProtocol, PassB: PassProtocol>(
+  passA: PassA, passB: PassB) -> JoinedPass<Input, Intermediate, Output,
+                                            PassA, PassB> {
+  return JoinedPass(passA: passA, passB: passB)
+}

--- a/Sources/Drill/Pass.swift
+++ b/Sources/Drill/Pass.swift
@@ -8,38 +8,6 @@
 import Foundation
 import Lithosphere
 
-/// A class that's passed to invocations of each pass. It contains a timer
-/// and diagnostic engine that each pass can make use of.
-class PassContext {
-  let timer = PassTimer()
-  let engine: DiagnosticEngine
-
-  init(engine: DiagnosticEngine) {
-    self.engine = engine
-  }
-}
-
-/// Defines the set of behaviors of a compiler pass. Passes can be thought of
-/// as functions from Input to Output, but which execute in a context.
-protocol PassProtocol {
-  /// The type of values that this pass consumes.
-  associatedtype Input
-
-  /// The type of output this pass transforms the Input into.
-  associatedtype Output
-
-  /// The display name of this pass (used for pass timing).
-  var name: String { get }
-
-  /// Runs this pass with the provided input in the provided context.
-  /// - parameters:
-  ///   - input: The input to this pass (usually output from a previous pass).
-  ///   - context: The pass context this pass will be executed in.
-  /// - returns: An optional transformed value based on the input. If this
-  ///            pass failed, it should return `nil` from this method.
-  func run(_ input: Input, in context: PassContext) -> Output?
-}
-
 /// A Pass is the most common currency for compiler passes. It wraps a function
 /// with the same signature as `PassProtocol`'s `run` method, and is responsible
 /// for invoking the pass timer before executing its actions.
@@ -68,77 +36,4 @@ struct Pass<In, Out>: PassProtocol {
       actions(input, context)
     }
   }
-}
-
-/// A PassComposition, analogous to function composition, executes one pass
-/// and pipes its output to the second pass. It converts two passes `(A) -> B`
-/// and `(B) -> C` into one pass, `(A) -> C`.
-struct PassComposition<PassA: PassProtocol, PassB: PassProtocol>: PassProtocol
-   where PassA.Output == PassB.Input {
-  let name = "PassComposition"
-
-  /// The first pass to execute.
-  let passA: PassA
-
-  /// The second pass to execute.
-  let passB: PassB
-
-
-  /// Runs the first pass and, if it returned a non-`nil` value, passes
-  /// the value to the second pass and returns that value.
-  ///
-  /// - Parameters:
-  ///   - input: The input to the first pass.
-  ///   - context: The context in which to execute the passes.
-  /// - Returns: The output of the second pass, or `nil` if either pass failed.
-  func run(_ input: PassA.Input, in context: PassContext) -> PassB.Output? {
-    return passA.run(input, in: context).flatMap {
-      passB.run($0, in: context)
-    }
-  }
-}
-
-/// A DiagnosticGatePass is a pass that wraps another pass and throws away its
-/// resulting value if any diagnostics were emitted.
-/// This is useful for passes that only communicate failure via diagnostics,
-/// like semantic analysis passes.
-struct DiagnosticGatePass<PassTy: PassProtocol>: PassProtocol {
-  /// The input of the underlying pass type.
-  typealias Input = PassTy.Input
-
-  /// The output of the underlying pass type.
-  typealias Output = PassTy.Output
-
-  var name: String {
-    return pass.name
-  }
-  let pass: PassTy
-
-  /// Creates a DiagnosticGatePass that wraps the provided pass.
-  /// - parameter pass: The pass to gate on diagnostic emission.
-  init(_ pass: PassTy) {
-    self.pass = pass
-  }
-
-  /// Runs the underlying pass, but doesn't forward the value if the
-  /// Diagnostic Engine registered an error.
-  func run(_ input: Input, in context: PassContext) -> Output? {
-    let output = pass.run(input, in: context)
-    return context.engine.hasErrors() ? nil : output
-  }
-}
-
-/// An operator that represents a composition of passes.
-infix operator |> : AdditionPrecedence
-
-
-/// Composes two passes together into one pass.
-///
-/// - Parameters:
-///   - passA: The first pass to run.
-///   - passB: The second pass to run if the first succeeds.
-/// - Returns: The output of the second pass, or `nil` if either pass failed.
-func |><PassA: PassProtocol, PassB: PassProtocol>(
-  passA: PassA, passB: PassB) -> PassComposition<PassA, PassB> {
-  return PassComposition(passA: passA, passB: passB)
 }

--- a/Sources/Drill/PassComposition.swift
+++ b/Sources/Drill/PassComposition.swift
@@ -1,0 +1,53 @@
+/// PassComposition.swift
+///
+/// Copyright 2017, The Silt Language Project.
+///
+/// This project is released under the MIT license, a copy of which is
+/// available in the repository.
+
+import Foundation
+import Lithosphere
+
+/// A PassComposition, analogous to function composition, executes one pass
+/// and pipes its output to the second pass. It converts two passes `(A) -> B`
+/// and `(B) -> C` into one pass, `(A) -> C`.
+struct PassComposition<PassA: PassProtocol, PassB: PassProtocol>: PassProtocol
+  where PassA.Output == PassB.Input
+{
+  let name = "PassComposition"
+
+  /// The first pass to execute.
+  let passA: PassA
+
+  /// The second pass to execute.
+  let passB: PassB
+
+
+  /// Runs the first pass and, if it returned a non-`nil` value, passes
+  /// the value to the second pass and returns that value.
+  ///
+  /// - Parameters:
+  ///   - input: The input to the first pass.
+  ///   - context: The context in which to execute the passes.
+  /// - Returns: The output of the second pass, or `nil` if either pass failed.
+  func run(_ input: PassA.Input, in context: PassContext) -> PassB.Output? {
+    return passA.run(input, in: context).flatMap {
+      passB.run($0, in: context)
+    }
+  }
+}
+
+/// An operator that represents a composition of passes.
+infix operator |> : AdditionPrecedence
+
+
+/// Composes two passes together into one pass.
+///
+/// - Parameters:
+///   - passA: The first pass to run.
+///   - passB: The second pass to run if the first succeeds.
+/// - Returns: The output of the second pass, or `nil` if either pass failed.
+func |> <PassA: PassProtocol, PassB: PassProtocol>(
+  passA: PassA, passB: PassB) -> PassComposition<PassA, PassB> {
+  return PassComposition(passA: passA, passB: passB)
+}

--- a/Sources/Drill/PassContext.swift
+++ b/Sources/Drill/PassContext.swift
@@ -1,0 +1,20 @@
+/// PassContext.swift
+///
+/// Copyright 2017, The Silt Language Project.
+///
+/// This project is released under the MIT license, a copy of which is
+/// available in the repository.
+
+import Foundation
+import Lithosphere
+
+/// A class that's passed to invocations of each pass. It contains a timer
+/// and diagnostic engine that each pass can make use of.
+final class PassContext {
+  /// A timer that records the running time of each individual pass.
+  let timer = PassTimer()
+
+  /// The diagnostic engine which passes should use to diagnose errors and
+  /// warnings.
+  let engine = DiagnosticEngine()
+}

--- a/Sources/Drill/PassProtocol.swift
+++ b/Sources/Drill/PassProtocol.swift
@@ -1,0 +1,30 @@
+/// PassProtocol.swift
+///
+/// Copyright 2017, The Silt Language Project.
+///
+/// This project is released under the MIT license, a copy of which is
+/// available in the repository.
+
+import Foundation
+import Lithosphere
+
+/// Defines the set of behaviors of a compiler pass. Passes can be thought of
+/// as functions from Input to Output, but which execute in a context.
+protocol PassProtocol {
+  /// The type of values that this pass consumes.
+  associatedtype Input
+
+  /// The type of output this pass transforms the Input into.
+  associatedtype Output
+
+  /// The display name of this pass (used for pass timing).
+  var name: String { get }
+
+  /// Runs this pass with the provided input in the provided context.
+  /// - parameters:
+  ///   - input: The input to this pass (usually output from a previous pass).
+  ///   - context: The pass context this pass will be executed in.
+  /// - returns: An optional transformed value based on the input. If this
+  ///            pass failed, it should return `nil` from this method.
+  func run(_ input: Input, in context: PassContext) -> Output?
+}

--- a/Sources/Drill/PassTimer.swift
+++ b/Sources/Drill/PassTimer.swift
@@ -9,26 +9,13 @@ import Foundation
 
 class PassTimer {
   private var timings = [(String, TimeInterval)]()
-  private var currentPass: String?
-  private var currentStart: TimeInterval?
 
-  func start(passName: String) {
-    guard currentPass == nil, currentStart == nil else {
-      fatalError("cannot begin measuring while measuring another pass")
+  func measure<Out>(pass: String, actions: () -> Out) -> Out {
+    let start = CFAbsoluteTimeGetCurrent()
+    defer {
+      let end = CFAbsoluteTimeGetCurrent()
+      timings.append((pass, end - start))
     }
-    currentPass = passName
-    currentStart = CFAbsoluteTimeGetCurrent()
-  }
-
-  func end(passName: String) {
-    guard let start = currentStart else {
-      fatalError("cannot end timer that has not begun")
-    }
-    guard currentPass == passName else {
-      fatalError("cannot end timer for \(currentPass!) with pass \(passName)")
-    }
-    timings.append((passName, CFAbsoluteTimeGetCurrent() - start))
-    currentStart = nil
-    currentPass = nil
+    return actions()
   }
 }

--- a/Sources/Drill/PassTimer.swift
+++ b/Sources/Drill/PassTimer.swift
@@ -1,0 +1,34 @@
+/// PassTimer.swift
+///
+/// Copyright 2017, The Silt Language Project.
+///
+/// This project is released under the MIT license, a copy of which is
+/// available in the repository.
+
+import Foundation
+
+class PassTimer {
+  private var timings = [(String, TimeInterval)]()
+  private var currentPass: String?
+  private var currentStart: TimeInterval?
+
+  func start(passName: String) {
+    guard currentPass == nil, currentStart == nil else {
+      fatalError("cannot begin measuring while measuring another pass")
+    }
+    currentPass = passName
+    currentStart = CFAbsoluteTimeGetCurrent()
+  }
+
+  func end(passName: String) {
+    guard let start = currentStart else {
+      fatalError("cannot end timer that has not begun")
+    }
+    guard currentPass == passName else {
+      fatalError("cannot end timer for \(currentPass!) with pass \(passName)")
+    }
+    timings.append((passName, CFAbsoluteTimeGetCurrent() - start))
+    currentStart = nil
+    currentPass = nil
+  }
+}

--- a/Sources/Drill/PassTimer.swift
+++ b/Sources/Drill/PassTimer.swift
@@ -18,4 +18,33 @@ class PassTimer {
     }
     return actions()
   }
+
+  func dump<Target: TextOutputStream>(to target: inout Target) {
+    var columns = [Column(title: "Pass"), Column(title: "Time")]
+    for (pass, time) in timings {
+      columns[0].rows.append(pass)
+      columns[1].rows.append(format(time: time))
+    }
+    TableFormatter(columns: columns).write(to: &target)
+  }
+}
+
+private func format(time: Double) -> String {
+  var time = time
+  let unit: String
+  let formatter = NumberFormatter()
+  formatter.maximumFractionDigits = 3
+  if time > 1.0 {
+    unit = "s"
+  } else if time > 0.001 {
+    unit = "ms"
+    time *= 1_000
+  } else if time > 0.000_001 {
+    unit = "µs"
+    time *= 1_000_000
+  } else {
+    unit = "ns"
+    time *= 1_000_000_000
+  }
+  return formatter.string(from: NSNumber(value: time))! + unit
 }

--- a/Sources/Drill/PassTimer.swift
+++ b/Sources/Drill/PassTimer.swift
@@ -7,10 +7,24 @@
 
 import Foundation
 
+/// A class that keeps track of the elapsed time of a sequence of compiler
+/// passes. It also includes behavior to dump a table of values representing the
+/// times of all passes run in the compile session.
 class PassTimer {
+  /// The order of passes executed.
   private var passOrder = [String]()
+
+  /// The time taken for each pass.
   private var timings = [String: TimeInterval]()
 
+
+  /// Measures the time taken for the underlying block, and returns whatever
+  /// value the underlying block returns.
+  ///
+  /// - Parameters:
+  ///   - pass: The name of the pass being executed.
+  ///   - actions: A function corresponding to the pass's actions.
+  /// - Returns: The return value of the pass.
   func measure<Out>(pass: String, actions: () -> Out) -> Out {
     // FIXME: Date() is wasteful here...
     let start = Date()
@@ -21,36 +35,51 @@ class PassTimer {
     return actions()
   }
 
+
+  /// Dumps a formatted table of timings to the provided stream.
+  ///
+  /// - Parameter target: The stream to write the table to.
   func dump<Target: TextOutputStream>(to target: inout Target) {
     var columns = [Column(title: "Pass"), Column(title: "Time")]
     for pass in passOrder {
       columns[0].rows.append(pass)
       if let time = timings[pass] {
-        columns[1].rows.append(format(time: time))
+        columns[1].rows.append(format(interval: time))
       } else {
         columns[1].rows.append("N/A")
       }
     }
-    TableFormatter(columns: columns).write(to: &target)
+    TableFormatter.write(columns: columns, to: &target)
   }
 }
 
-private func format(time: Double) -> String {
-  var time = time
-  let unit: String
+/// A NumberFormatter used for printing formatted time intervals.
+private let intervalFormatter: NumberFormatter = {
   let formatter = NumberFormatter()
   formatter.maximumFractionDigits = 1
-  if time > 1.0 {
+  return formatter
+}()
+
+/// Formats a time interval at second, millisecond, microsecond, and nanosecond
+/// boundaries.
+///
+/// - Parameter interval: The interval you're formatting.
+/// - Returns: A stringified version of the time interval, including the most
+///            appropriate unit.
+private func format(interval: TimeInterval) -> String {
+  var interval = interval
+  let unit: String
+  if interval > 1.0 {
     unit = "s"
-  } else if time > 0.001 {
+  } else if interval > 0.001 {
     unit = "ms"
-    time *= 1_000
-  } else if time > 0.000_001 {
+    interval *= 1_000
+  } else if interval > 0.000_001 {
     unit = "µs"
-    time *= 1_000_000
+    interval *= 1_000_000
   } else {
     unit = "ns"
-    time *= 1_000_000_000
+    interval *= 1_000_000_000
   }
-  return formatter.string(from: NSNumber(value: time))! + unit
+  return intervalFormatter.string(from: NSNumber(value: interval))! + unit
 }

--- a/Sources/Drill/PassTimer.swift
+++ b/Sources/Drill/PassTimer.swift
@@ -8,22 +8,28 @@
 import Foundation
 
 class PassTimer {
-  private var timings = [(String, TimeInterval)]()
+  private var passOrder = [String]()
+  private var timings = [String: TimeInterval]()
 
   func measure<Out>(pass: String, actions: () -> Out) -> Out {
     // FIXME: Date() is wasteful here...
     let start = Date()
     defer {
-      timings.append((pass, Date().timeIntervalSince(start)))
+      passOrder.append(pass)
+      timings[pass, default: 0] += Date().timeIntervalSince(start)
     }
     return actions()
   }
 
   func dump<Target: TextOutputStream>(to target: inout Target) {
     var columns = [Column(title: "Pass"), Column(title: "Time")]
-    for (pass, time) in timings {
+    for pass in passOrder {
       columns[0].rows.append(pass)
-      columns[1].rows.append(format(time: time))
+      if let time = timings[pass] {
+        columns[1].rows.append(format(time: time))
+      } else {
+        columns[1].rows.append("N/A")
+      }
     }
     TableFormatter(columns: columns).write(to: &target)
   }

--- a/Sources/Drill/PassTimer.swift
+++ b/Sources/Drill/PassTimer.swift
@@ -11,10 +11,10 @@ class PassTimer {
   private var timings = [(String, TimeInterval)]()
 
   func measure<Out>(pass: String, actions: () -> Out) -> Out {
-    let start = CFAbsoluteTimeGetCurrent()
+    // FIXME: Date() is wasteful here...
+    let start = Date()
     defer {
-      let end = CFAbsoluteTimeGetCurrent()
-      timings.append((pass, end - start))
+      timings.append((pass, Date().timeIntervalSince(start)))
     }
     return actions()
   }

--- a/Sources/Drill/PassTimer.swift
+++ b/Sources/Drill/PassTimer.swift
@@ -33,7 +33,7 @@ private func format(time: Double) -> String {
   var time = time
   let unit: String
   let formatter = NumberFormatter()
-  formatter.maximumFractionDigits = 3
+  formatter.maximumFractionDigits = 1
   if time > 1.0 {
     unit = "s"
   } else if time > 0.001 {

--- a/Sources/Drill/StandardPasses.swift
+++ b/Sources/Drill/StandardPasses.swift
@@ -1,0 +1,42 @@
+//
+//  StandardPasses.swift
+//  Drill
+//
+//  Created by Harlan Haskins on 11/28/17.
+//
+
+import Foundation
+import Lithosphere
+import Crust
+import Moho
+
+enum Passes {
+  static let lex =
+    Pass<URL, [TokenSyntax]>(name: "Lex") { url, ctx in
+      do {
+        let contents = try String(contentsOf: url, encoding: .utf8)
+        let lexer = Lexer(input: contents, filePath: url.path)
+        return lexer.tokenize()
+      } catch {
+        ctx.engine.diagnose(.couldNotReadInput(url))
+        return nil
+      }
+    }
+
+  static let shine =
+    Pass<[TokenSyntax], [TokenSyntax]>(name: "Shine") { tokens, ctx in
+      layout(tokens)
+    }
+
+  static let parse =
+    Pass<[TokenSyntax], ModuleDeclSyntax>(name: "Parse") { tokens, ctx in
+      let parser = Parser(diagnosticEngine: ctx.engine, tokens: tokens)
+      return parser.parseTopLevelModule()
+    }
+
+  static let scopeCheck =
+    Pass<ModuleDeclSyntax, DeclaredModule>(name: "Scope Check") { module, ctx in
+      let binder = NameBinding(topLevel: module, engine: ctx.engine)
+      return binder.performScopeCheck(topLevel: module)
+    }
+}

--- a/Sources/Drill/StandardPasses.swift
+++ b/Sources/Drill/StandardPasses.swift
@@ -11,6 +11,8 @@ import Crust
 import Moho
 
 enum Passes {
+  /// The Lex pass reads a URL from the file system and tokenizes it into a
+  /// stream of TokenSyntax nodes.
   static let lex =
     Pass<URL, [TokenSyntax]>(name: "Lex") { url, ctx in
       do {
@@ -23,17 +25,23 @@ enum Passes {
       }
     }
 
+  /// The Shine pass takes a token stream and adds additional implicit tokens
+  /// representing the beginning and ends of scopes.
   static let shine =
     Pass<[TokenSyntax], [TokenSyntax]>(name: "Shine") { tokens, ctx in
       layout(tokens)
     }
 
+  /// The Parse pass runs the parser over a Shined token stream and produces a
+  /// full-fledged Syntax tree.
   static let parse =
     Pass<[TokenSyntax], ModuleDeclSyntax>(name: "Parse") { tokens, ctx in
       let parser = Parser(diagnosticEngine: ctx.engine, tokens: tokens)
       return parser.parseTopLevelModule()
     }
 
+  /// The ScopeCheck pass ensures the program is well-scoped and doesn't use
+  /// unreachable variables.
   static let scopeCheck =
     DiagnosticGatePass(
       Pass<ModuleDeclSyntax, DeclaredModule>(name: "Scope Check") {

--- a/Sources/Drill/StandardPasses.swift
+++ b/Sources/Drill/StandardPasses.swift
@@ -11,18 +11,24 @@ import Crust
 import Moho
 
 enum Passes {
-  /// The Lex pass reads a URL from the file system and tokenizes it into a
-  /// stream of TokenSyntax nodes.
-  static let lex =
-    Pass<URL, [TokenSyntax]>(name: "Lex") { url, ctx in
+  /// Reads a file and returns both the String contents of the file and
+  /// the URL of the file.
+  static let readFile =
+    Pass<URL, (String, URL)>(name: "Read File") { url, ctx in
       do {
-        let contents = try String(contentsOf: url, encoding: .utf8)
-        let lexer = Lexer(input: contents, filePath: url.path)
-        return lexer.tokenize()
+        return (try String(contentsOf: url, encoding: .utf8), url)
       } catch {
         ctx.engine.diagnose(.couldNotReadInput(url))
         return nil
       }
+    }
+
+  /// The Lex pass reads a URL from the file system and tokenizes it into a
+  /// stream of TokenSyntax nodes.
+  static let lex =
+    Pass<(String, URL), [TokenSyntax]>(name: "Lex") { file, ctx in
+      let lexer = Lexer(input: file.0, filePath: file.1.path)
+      return lexer.tokenize()
     }
 
   /// The Shine pass takes a token stream and adds additional implicit tokens

--- a/Sources/Drill/StandardPasses.swift
+++ b/Sources/Drill/StandardPasses.swift
@@ -35,8 +35,10 @@ enum Passes {
     }
 
   static let scopeCheck =
-    Pass<ModuleDeclSyntax, DeclaredModule>(name: "Scope Check") { module, ctx in
-      let binder = NameBinding(topLevel: module, engine: ctx.engine)
-      return binder.performScopeCheck(topLevel: module)
-    }
+    DiagnosticGatePass(
+      Pass<ModuleDeclSyntax, DeclaredModule>(name: "Scope Check") {
+        module, ctx in
+        let binder = NameBinding(topLevel: module, engine: ctx.engine)
+        return binder.performScopeCheck(topLevel: module)
+      })
 }

--- a/Sources/Drill/TableFormatter.swift
+++ b/Sources/Drill/TableFormatter.swift
@@ -1,0 +1,74 @@
+///
+/// TableFormatter.swift
+///
+/// Copyright 2016-2017 the Trill project authors.
+/// Licensed under the MIT License.
+///
+/// Full license text available at https://github.com/trill-lang/trill
+///
+
+import Foundation
+
+struct Column {
+  let title: String
+  var rows = [String]()
+  init(title: String) {
+    self.title = title
+  }
+  var width: Int {
+    var longest = self.title.count
+    for row in self.rows where row.count > longest {
+      longest = row.count
+    }
+    return longest
+  }
+}
+
+class TableFormatter<StreamType: TextOutputStream> {
+  let columns: [Column]
+
+  init(columns:  [Column]) {
+    self.columns = columns
+  }
+
+  func write(to stream: inout StreamType) {
+    let widths = columns.map { $0.width }
+    stream.write("┏")
+    for (idx, width) in widths.enumerated() {
+      stream.write(String(repeating: "━", count: width + 2))
+      if idx == widths.endIndex - 1 {
+        stream.write("┓\n")
+      } else {
+        stream.write("┳")
+      }
+    }
+    for (column, width) in zip(columns, widths) {
+      stream.write("┃ \(column.title.padded(to: width)) ")
+    }
+    stream.write("┃\n")
+    for (index, width) in widths.enumerated() {
+      let separator = index == widths.startIndex ? "┣" : "╋"
+      stream.write(separator)
+      stream.write(String(repeating: "━", count: width + 2))
+    }
+    stream.write("┫\n")
+    for row in 0..<columns[0].rows.count {
+      for (column, width) in zip(columns, widths) {
+        stream.write("┃ \(column.rows[row].padded(to: width)) ")
+      }
+      stream.write("┃\n")
+    }
+    stream.write("┗")
+    for (idx, width) in widths.enumerated() {
+      stream.write(String(repeating: "━", count: width + 2))
+      stream.write(idx == widths.endIndex - 1 ? "┛\n" : "┻")
+    }
+  }
+}
+
+extension String {
+  func padded(to length: Int, with padding: String = " ") -> String {
+    let padded = String(repeating: padding, count: length - count)
+    return self + padded
+  }
+}

--- a/Sources/Drill/TableFormatter.swift
+++ b/Sources/Drill/TableFormatter.swift
@@ -1,20 +1,26 @@
-///
 /// TableFormatter.swift
 ///
-/// Copyright 2016-2017 the Trill project authors.
-/// Licensed under the MIT License.
+/// Copyright 2017, The Silt Language Project.
 ///
-/// Full license text available at https://github.com/trill-lang/trill
-///
+/// This project is released under the MIT license, a copy of which is
+/// available in the repository.
 
 import Foundation
 
+/// Represents a column of tabular values, including a title and rows.
 struct Column {
+  /// The column's title.
   let title: String
+
+  /// the rows in the column.
   var rows = [String]()
+
+  /// Creates an empty column with the provided title.
   init(title: String) {
     self.title = title
   }
+
+  /// The length of the longest line in this column.
   var width: Int {
     var longest = self.title.count
     for row in self.rows where row.count > longest {
@@ -24,14 +30,25 @@ struct Column {
   }
 }
 
-class TableFormatter<StreamType: TextOutputStream> {
-  let columns: [Column]
-
-  init(columns:  [Column]) {
-    self.columns = columns
-  }
-
-  func write(to stream: inout StreamType) {
+/// An object that formats a set of columns to an output stream as an ASCII
+/// table.
+enum TableFormatter {
+  /// Writes the provided columns as an ASCII table to the provided output
+  /// stream. It takes into account the lengths of the columns and ensures a
+  /// perfectly-formatted box.
+  /// Example:
+  /// ```
+  /// ┏━━━━━━━━━━━━━┳━━━━━━━━━┓
+  /// ┃ Pass        ┃ Time    ┃
+  /// ┣━━━━━━━━━━━━━╋━━━━━━━━━┫
+  /// ┃ Lex         ┃ 7.4ms   ┃
+  /// ┃ Shine       ┃ 1.1ms   ┃
+  /// ┃ Parse       ┃ 3ms     ┃
+  /// ┃ Dump Parsed ┃ 136.8ms ┃
+  /// ┗━━━━━━━━━━━━━┻━━━━━━━━━┛
+  /// ```
+  static func write<StreamType: TextOutputStream>(
+    columns: [Column], to stream: inout StreamType) {
     let widths = columns.map { $0.width }
     stream.write("┏")
     for (idx, width) in widths.enumerated() {
@@ -67,6 +84,8 @@ class TableFormatter<StreamType: TextOutputStream> {
 }
 
 extension String {
+  /// Right-pads the given string to the provided length, optionally accepting
+  /// a different padding string.
   func padded(to length: Int, with padding: String = " ") -> String {
     let padded = String(repeating: padding, count: length - count)
     return self + padded

--- a/Sources/silt/main.swift
+++ b/Sources/silt/main.swift
@@ -29,8 +29,11 @@ func parseOptions() -> (Options, Set<String>) {
       helpMessage: "Run the compiler in diagnostic verifier mode.")
   let disableColors =
     BoolOption(longFlag: "no-colors",
-               helpMessage: "Disable ANSI colors in printed output.")
-  cli.addOptions(dumpOption, verify, disableColors)
+      helpMessage: "Disable ANSI colors in printed output.")
+  let printTiming =
+    BoolOption(longFlag: "debug-print-timing",
+      helpMessage: "Print the elapsed time for each pass of the compiler")
+  cli.addOptions(dumpOption, verify, disableColors, printTiming)
 
   do {
     try cli.parse()
@@ -49,7 +52,8 @@ func parseOptions() -> (Options, Set<String>) {
   }
 
   return (Options(mode: mode,
-                  colorsEnabled: !disableColors.value),
+                  colorsEnabled: !disableColors.value,
+                  shouldPrintTiming: printTiming.value),
           Set(cli.unparsedArguments))
 }
 


### PR DESCRIPTION
### What's in this pull request?

This patch describes a change to how we structure passes of the compiler. It rethinks the notion of a compiler pass as a function from `Input` to `Output` and provides easy structures for composing passes together. It also bakes in the notion of profiling passes into a "Pass Context" which also contains the diagnostic engine. I can't think of other things this pass context would need.

### Why merge this pull request?

We've been mulling over a pass/driver structure for a long time, and since we're starting to add Actual Functionality™, we should really formalize these things to avoid copy/pasting a bunch of code.

### What's worth discussing about this pull request?

Everything -- I want to know if this pass structure is a good direction or if I should rethink it.

### What downsides are there to merging this pull request?

I want to discuss this a lot.
