### PR TITLE
Collective bargaining

### DIFF
--- a/Sources/Lithosphere/SyntaxCollection.swift
+++ b/Sources/Lithosphere/SyntaxCollection.swift
@@ -15,12 +15,19 @@ import Foundation
 /// Represents a collection of Syntax nodes of a specific type. SyntaxCollection
 /// behaves as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public class SyntaxCollection<SyntaxElement: Syntax>: Syntax {
+public final class SyntaxCollection<SyntaxElement: Syntax>: Syntax {
   internal override init(root: SyntaxData, data: SyntaxData) {
     super.init(root: root, data: data)
   }
 
-  internal init(kind: SyntaxKind, elements: [SyntaxElement]) {
+  public init(elements: [SyntaxElement]) {
+    let syntaxId = ObjectIdentifier(SyntaxElement.self)
+    guard let kind = SyntaxCollection.syntaxCollectionKinds[syntaxId] else {
+      fatalError("""
+                 Attempted to initialize syntax collection with unknown syntax \
+                 type '\(type(of: SyntaxElement.self))'
+                 """)
+    }
     let list = elements.map { $0.raw }
     let sd = SyntaxData(raw: .node(kind, list, .present))
     super.init(root: sd, data: sd)

--- a/Sources/Lithosphere/SyntaxKind.swift
+++ b/Sources/Lithosphere/SyntaxKind.swift
@@ -25,7 +25,6 @@ public enum SyntaxKind {
   case constructorList
   case constructorDecl
   case recordDecl
-  case recordElementList
   case fieldDecl
   case recordConstructorDecl
   case recordFieldAssignmentList
@@ -39,7 +38,6 @@ public enum SyntaxKind {
   case leftFixDecl
   case rightFixDecl
   case patternClauseList
-  case typedParameterArrowExpr
   case lambdaExpr
   case quantifiedExpr
   case letExpr
@@ -54,6 +52,7 @@ public enum SyntaxKind {
   case underscoreExpr
   case typeBasicExpr
   case parenthesizedExpr
+  case typedParameterGroupExpr
   case recordExpr
   case functionClauseList
   case reparsedFunctionDecl
@@ -115,8 +114,6 @@ extension Syntax {
       return ConstructorDeclSyntax(root: root, data: data)
     case .recordDecl:
       return RecordDeclSyntax(root: root, data: data)
-    case .recordElementList:
-      return RecordElementListSyntax(root: root, data: data)
     case .fieldDecl:
       return FieldDeclSyntax(root: root, data: data)
     case .recordConstructorDecl:
@@ -143,8 +140,6 @@ extension Syntax {
       return RightFixDeclSyntax(root: root, data: data)
     case .patternClauseList:
       return PatternClauseListSyntax(root: root, data: data)
-    case .typedParameterArrowExpr:
-      return TypedParameterArrowExprSyntax(root: root, data: data)
     case .lambdaExpr:
       return LambdaExprSyntax(root: root, data: data)
     case .quantifiedExpr:
@@ -173,6 +168,8 @@ extension Syntax {
       return TypeBasicExprSyntax(root: root, data: data)
     case .parenthesizedExpr:
       return ParenthesizedExprSyntax(root: root, data: data)
+    case .typedParameterGroupExpr:
+      return TypedParameterGroupExprSyntax(root: root, data: data)
     case .recordExpr:
       return RecordExprSyntax(root: root, data: data)
     case .functionClauseList:

--- a/Sources/Lithosphere/SyntaxNodes.swift
+++ b/Sources/Lithosphere/SyntaxNodes.swift
@@ -7,23 +7,9 @@
 /// available in the repository.
 public class ExprSyntax: Syntax {}
 public class DeclSyntax: Syntax {}
-public final class IdentifierListSyntax: SyntaxCollection<TokenSyntax> {
-  internal override init(root: SyntaxData, data: SyntaxData) {
-    super.init(root: root, data: data)
-  }
-  public init(elements: [TokenSyntax]) {
-    super.init(kind: .identifierList, elements: elements)
-  }
-}
+public typealias IdentifierListSyntax = SyntaxCollection<TokenSyntax>
 
-public final class QualifiedNameSyntax: SyntaxCollection<QualifiedNamePieceSyntax> {
-  internal override init(root: SyntaxData, data: SyntaxData) {
-    super.init(root: root, data: data)
-  }
-  public init(elements: [QualifiedNamePieceSyntax]) {
-    super.init(kind: .qualifiedName, elements: elements)
-  }
-}
+public typealias QualifiedNameSyntax = SyntaxCollection<QualifiedNamePieceSyntax>
 
 public class QualifiedNamePieceSyntax: Syntax {
   public enum Cursor: Int {
@@ -149,14 +135,7 @@ public class ModuleDeclSyntax: DeclSyntax {
 
 }
 
-public final class DeclListSyntax: SyntaxCollection<DeclSyntax> {
-  internal override init(root: SyntaxData, data: SyntaxData) {
-    super.init(root: root, data: data)
-  }
-  public init(elements: [DeclSyntax]) {
-    super.init(kind: .declList, elements: elements)
-  }
-}
+public typealias DeclListSyntax = SyntaxCollection<DeclSyntax>
 
 public class OpenImportDeclSyntax: DeclSyntax {
   public enum Cursor: Int {
@@ -366,14 +345,7 @@ public class TypeIndicesSyntax: Syntax {
 
 }
 
-public final class TypedParameterListSyntax: SyntaxCollection<TypedParameterSyntax> {
-  internal override init(root: SyntaxData, data: SyntaxData) {
-    super.init(root: root, data: data)
-  }
-  public init(elements: [TypedParameterSyntax]) {
-    super.init(kind: .typedParameterList, elements: elements)
-  }
-}
+public typealias TypedParameterListSyntax = SyntaxCollection<TypedParameterSyntax>
 
 public class AscriptionSyntax: Syntax {
   public enum Cursor: Int {
@@ -511,14 +483,7 @@ public class ImplicitTypedParameterSyntax: TypedParameterSyntax {
 
 }
 
-public final class ConstructorListSyntax: SyntaxCollection<ConstructorDeclSyntax> {
-  internal override init(root: SyntaxData, data: SyntaxData) {
-    super.init(root: root, data: data)
-  }
-  public init(elements: [ConstructorDeclSyntax]) {
-    super.init(kind: .constructorList, elements: elements)
-  }
-}
+public typealias ConstructorListSyntax = SyntaxCollection<ConstructorDeclSyntax>
 
 public class ConstructorDeclSyntax: DeclSyntax {
   public enum Cursor: Int {
@@ -575,7 +540,7 @@ public class RecordDeclSyntax: DeclSyntax {
     case trailingSemicolon
   }
 
-  public convenience init(recordToken: TokenSyntax, recordName: TokenSyntax, parameterList: TypedParameterListSyntax, typeIndices: TypeIndicesSyntax?, whereToken: TokenSyntax, leftParenToken: TokenSyntax, recordElementList: RecordElementListSyntax, rightParenToken: TokenSyntax, trailingSemicolon: TokenSyntax) {
+  public convenience init(recordToken: TokenSyntax, recordName: TokenSyntax, parameterList: TypedParameterListSyntax, typeIndices: TypeIndicesSyntax?, whereToken: TokenSyntax, leftParenToken: TokenSyntax, recordElementList: DeclListSyntax, rightParenToken: TokenSyntax, trailingSemicolon: TokenSyntax) {
     let raw = RawSyntax.node(.recordDecl, [
       recordToken.raw,
       recordName.raw,
@@ -638,10 +603,10 @@ public class RecordDeclSyntax: DeclSyntax {
     return RecordDeclSyntax(root: newRoot, data: newData)
   }
 
-  public var recordElementList: RecordElementListSyntax {
-    return child(at: Cursor.recordElementList) as! RecordElementListSyntax
+  public var recordElementList: DeclListSyntax {
+    return child(at: Cursor.recordElementList) as! DeclListSyntax
   }
-  public func withRecordElementList(_ syntax: RecordElementListSyntax) -> RecordDeclSyntax {
+  public func withRecordElementList(_ syntax: DeclListSyntax) -> RecordDeclSyntax {
     let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.recordElementList)
     return RecordDeclSyntax(root: newRoot, data: newData)
   }
@@ -662,15 +627,6 @@ public class RecordDeclSyntax: DeclSyntax {
     return RecordDeclSyntax(root: newRoot, data: newData)
   }
 
-}
-
-public final class RecordElementListSyntax: SyntaxCollection<DeclSyntax> {
-  internal override init(root: SyntaxData, data: SyntaxData) {
-    super.init(root: root, data: data)
-  }
-  public init(elements: [DeclSyntax]) {
-    super.init(kind: .recordElementList, elements: elements)
-  }
 }
 
 public class FieldDeclSyntax: DeclSyntax {
@@ -757,14 +713,7 @@ public class RecordConstructorDeclSyntax: DeclSyntax {
 
 }
 
-public final class RecordFieldAssignmentListSyntax: SyntaxCollection<RecordFieldAssignmentSyntax> {
-  internal override init(root: SyntaxData, data: SyntaxData) {
-    super.init(root: root, data: data)
-  }
-  public init(elements: [RecordFieldAssignmentSyntax]) {
-    super.init(kind: .recordFieldAssignmentList, elements: elements)
-  }
-}
+public typealias RecordFieldAssignmentListSyntax = SyntaxCollection<RecordFieldAssignmentSyntax>
 
 public class RecordFieldAssignmentSyntax: Syntax {
   public enum Cursor: Int {
@@ -1160,56 +1109,7 @@ public class RightFixDeclSyntax: FixityDeclSyntax {
 
 }
 
-public final class PatternClauseListSyntax: SyntaxCollection<ExprSyntax> {
-  internal override init(root: SyntaxData, data: SyntaxData) {
-    super.init(root: root, data: data)
-  }
-  public init(elements: [ExprSyntax]) {
-    super.init(kind: .patternClauseList, elements: elements)
-  }
-}
-
-public class TypedParameterArrowExprSyntax: ExprSyntax {
-  public enum Cursor: Int {
-    case parameters
-    case arrowToken
-    case outputExpr
-  }
-
-  public convenience init(parameters: TypedParameterListSyntax, arrowToken: TokenSyntax, outputExpr: ExprSyntax) {
-    let raw = RawSyntax.node(.typedParameterArrowExpr, [
-      parameters.raw,
-      arrowToken.raw,
-      outputExpr.raw,
-    ], .present)
-    let data = SyntaxData(raw: raw, indexInParent: 0, parent: nil)
-    self.init(root: data, data: data)
-  }
-  public var parameters: TypedParameterListSyntax {
-    return child(at: Cursor.parameters) as! TypedParameterListSyntax
-  }
-  public func withParameters(_ syntax: TypedParameterListSyntax) -> TypedParameterArrowExprSyntax {
-    let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.parameters)
-    return TypedParameterArrowExprSyntax(root: newRoot, data: newData)
-  }
-
-  public var arrowToken: TokenSyntax {
-    return child(at: Cursor.arrowToken) as! TokenSyntax
-  }
-  public func withArrowToken(_ syntax: TokenSyntax) -> TypedParameterArrowExprSyntax {
-    let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.arrowToken)
-    return TypedParameterArrowExprSyntax(root: newRoot, data: newData)
-  }
-
-  public var outputExpr: ExprSyntax {
-    return child(at: Cursor.outputExpr) as! ExprSyntax
-  }
-  public func withOutputExpr(_ syntax: ExprSyntax) -> TypedParameterArrowExprSyntax {
-    let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.outputExpr)
-    return TypedParameterArrowExprSyntax(root: newRoot, data: newData)
-  }
-
-}
+public typealias PatternClauseListSyntax = SyntaxCollection<ExprSyntax>
 
 public class LambdaExprSyntax: ExprSyntax {
   public enum Cursor: Int {
@@ -1399,14 +1299,7 @@ public class BasicExprSyntax: ExprSyntax {
   }
 }
 
-public final class BindingListSyntax: SyntaxCollection<BindingSyntax> {
-  internal override init(root: SyntaxData, data: SyntaxData) {
-    super.init(root: root, data: data)
-  }
-  public init(elements: [BindingSyntax]) {
-    super.init(kind: .bindingList, elements: elements)
-  }
-}
+public typealias BindingListSyntax = SyntaxCollection<BindingSyntax>
 
 public class BindingSyntax: Syntax {
 
@@ -1462,14 +1355,7 @@ public class TypedBindingSyntax: BindingSyntax {
 
 }
 
-public final class BasicExprListSyntax: SyntaxCollection<BasicExprSyntax> {
-  internal override init(root: SyntaxData, data: SyntaxData) {
-    super.init(root: root, data: data)
-  }
-  public init(elements: [BasicExprSyntax]) {
-    super.init(kind: .basicExprList, elements: elements)
-  }
-}
+public typealias BasicExprListSyntax = SyntaxCollection<BasicExprSyntax>
 
 public class NamedBasicExprSyntax: BasicExprSyntax {
   public enum Cursor: Int {
@@ -1579,6 +1465,28 @@ public class ParenthesizedExprSyntax: BasicExprSyntax {
 
 }
 
+public class TypedParameterGroupExprSyntax: BasicExprSyntax {
+  public enum Cursor: Int {
+    case parameters
+  }
+
+  public convenience init(parameters: TypedParameterListSyntax) {
+    let raw = RawSyntax.node(.typedParameterGroupExpr, [
+      parameters.raw,
+    ], .present)
+    let data = SyntaxData(raw: raw, indexInParent: 0, parent: nil)
+    self.init(root: data, data: data)
+  }
+  public var parameters: TypedParameterListSyntax {
+    return child(at: Cursor.parameters) as! TypedParameterListSyntax
+  }
+  public func withParameters(_ syntax: TypedParameterListSyntax) -> TypedParameterGroupExprSyntax {
+    let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.parameters)
+    return TypedParameterGroupExprSyntax(root: newRoot, data: newData)
+  }
+
+}
+
 public class RecordExprSyntax: BasicExprSyntax {
   public enum Cursor: Int {
     case recordToken
@@ -1641,14 +1549,7 @@ public class RecordExprSyntax: BasicExprSyntax {
 
 }
 
-public final class FunctionClauseListSyntax: SyntaxCollection<FunctionClauseDeclSyntax> {
-  internal override init(root: SyntaxData, data: SyntaxData) {
-    super.init(root: root, data: data)
-  }
-  public init(elements: [FunctionClauseDeclSyntax]) {
-    super.init(kind: .functionClauseList, elements: elements)
-  }
-}
+public typealias FunctionClauseListSyntax = SyntaxCollection<FunctionClauseDeclSyntax>
 
 public class ReparsedFunctionDeclSyntax: DeclSyntax {
   public enum Cursor: Int {
@@ -1714,3 +1615,19 @@ public class ReparsedApplicationExprSyntax: BasicExprSyntax {
 
 }
 
+extension SyntaxCollection {
+  static var syntaxCollectionKinds: [ObjectIdentifier: SyntaxKind] {
+    return [
+      ObjectIdentifier(TokenSyntax.self): .identifierList, 
+      ObjectIdentifier(QualifiedNamePieceSyntax.self): .qualifiedName, 
+      ObjectIdentifier(DeclSyntax.self): .declList, 
+      ObjectIdentifier(TypedParameterSyntax.self): .typedParameterList, 
+      ObjectIdentifier(ConstructorDeclSyntax.self): .constructorList, 
+      ObjectIdentifier(RecordFieldAssignmentSyntax.self): .recordFieldAssignmentList, 
+      ObjectIdentifier(ExprSyntax.self): .patternClauseList, 
+      ObjectIdentifier(BindingSyntax.self): .bindingList, 
+      ObjectIdentifier(BasicExprSyntax.self): .basicExprList, 
+      ObjectIdentifier(FunctionClauseDeclSyntax.self): .functionClauseList, 
+    ]
+  }
+}

--- a/Sources/SyntaxGen/SyntaxNodes.swift
+++ b/Sources/SyntaxGen/SyntaxNodes.swift
@@ -137,11 +137,6 @@ let syntaxNodes = [
     Child("trailingSemicolon", kind: "SemicolonToken"),
   ]),
 
-  // record-element-list ::= <record-element>
-  //                       | <record-element> ';' <record-element-list>
-
-  Node("RecordElementList", element: "Decl"),
-
   // record-element ::= <field-decl>
   //                  | <function-decl>
   //                  | <record-constructor-decl>
@@ -243,19 +238,12 @@ let syntaxNodes = [
 
   // Expressions
 
-  // expr ::= <typed-parameter-list> '->' <expr>
-  //        | <basic-expr-list> '->' <expr>
+  // expr ::= <basic-expr-list> '->' <expr>
   //        | '\' <binding-list> <expr>
   //        | 'forall' <typed-parameter-list> '->' <expr>
   //        | 'let' <decl-list> 'in' <expr>
   //        | <application>
   //        | <basic-expr>
-
-  Node("TypedParameterArrowExpr", kind: "Expr", children: [
-    Child("parameters", kind: "TypedParameterList"),
-    Child("arrowToken", kind: "ArrowToken"),
-    Child("outputExpr", kind: "Expr")
-  ]),
 
   Node("LambdaExpr", kind: "Expr", children: [
     Child("slashToken", kind: "ForwardSlashToken"),
@@ -311,6 +299,7 @@ let syntaxNodes = [
   // basic-expr ::= <qualified-name>
   //              | '_'
   //              | 'Type'
+  //              | <typed-parameter-list>
   //              | '(' <expr> ')'
   //              | 'record' <basic-expr>? '{' <record-field-assignment-list>? '}'
 
@@ -330,6 +319,10 @@ let syntaxNodes = [
     Child("leftParenToken", kind: "LeftParenToken"),
     Child("expr", kind: "Expr"),
     Child("rightParenToken", kind: "RightParenToken")
+  ]),
+
+  Node("TypedParameterGroupExpr", kind: "BasicExpr", children: [
+    Child("parameters", kind: "TypedParameterList"),
   ]),
 
   Node("RecordExpr", kind: "BasicExpr", children: [

--- a/Sources/SyntaxGen/SyntaxNodes.swift
+++ b/Sources/SyntaxGen/SyntaxNodes.swift
@@ -132,7 +132,7 @@ let syntaxNodes = [
     Child("typeIndices", kind: "TypeIndices", isOptional: true),
     Child("whereToken", kind: "WhereToken"),
     Child("leftParenToken", kind: "LeftParenToken"),
-    Child("recordElementList", kind: "RecordElementList"),
+    Child("recordElementList", kind: "DeclList"),
     Child("rightParenToken", kind: "RightParenToken"),
     Child("trailingSemicolon", kind: "SemicolonToken"),
   ]),

--- a/Tests/Lite/Parse/ambiguous-parens.silt
+++ b/Tests/Lite/Parse/ambiguous-parens.silt
@@ -1,0 +1,8 @@
+-- RUN: --verify parse
+module ambiguous-parens where
+
+-- #49: Used to have trouble parsing this because we couldn't tell the
+-- difference between '(a b c ...)' the application and '(a b c ... : Foo)' the
+-- parameter list.
+foo a b c = (a b c)
+

--- a/Tests/SyntaxTests/Resources/basics.silt.ast
+++ b/Tests/SyntaxTests/Resources/basics.silt.ast
@@ -1,4 +1,4 @@
--- CHECK: (moduleDecl basics.silt:2:0
+-- CHECK:      (moduleDecl basics.silt:2:0
 -- CHECK-NEXT:   (moduleKeyword basics.silt:2:0)
 -- CHECK-NEXT:   (qualifiedName basics.silt:2:7
 -- CHECK-NEXT:     (qualifiedNamePiece basics.silt:2:7
@@ -163,49 +163,52 @@
 -- CHECK-NEXT:             (basicExprList basics.silt:8:14
 -- CHECK-NEXT:               (parenthesizedExpr basics.silt:8:14
 -- CHECK-NEXT:                 (leftParen basics.silt:8:14)
--- CHECK-NEXT:                 (typedParameterArrowExpr basics.silt:8:15
--- CHECK-NEXT:                   (typedParameterList basics.silt:8:15
--- CHECK-NEXT:                     (explicitTypedParameter basics.silt:8:15
--- CHECK-NEXT:                       (leftParen basics.silt:8:15)
--- CHECK-NEXT:                       (ascription basics.silt:8:16
--- CHECK-NEXT:                         (identifierList basics.silt:8:16
--- CHECK-NEXT:                           (identifier "x" basics.silt:8:16))
--- CHECK-NEXT:                         (colon basics.silt:8:18)
--- CHECK-NEXT:                         (applicationExpr basics.silt:8:20
--- CHECK-NEXT:                           (basicExprList basics.silt:8:20
--- CHECK-NEXT:                             (namedBasicExpr basics.silt:8:20
--- CHECK-NEXT:                               (qualifiedName basics.silt:8:20
--- CHECK-NEXT:                                 (qualifiedNamePiece basics.silt:8:20
--- CHECK-NEXT:                                   (identifier "A" basics.silt:8:20)))))))
--- CHECK-NEXT:                       (rightParen basics.silt:8:21))
--- CHECK-NEXT:                     (explicitTypedParameter basics.silt:8:23
--- CHECK-NEXT:                       (leftParen basics.silt:8:23)
--- CHECK-NEXT:                       (ascription basics.silt:8:24
--- CHECK-NEXT:                         (identifierList basics.silt:8:24
--- CHECK-NEXT:                           (identifier "y" basics.silt:8:24))
--- CHECK-NEXT:                         (colon basics.silt:8:26)
--- CHECK-NEXT:                         (applicationExpr basics.silt:8:28
--- CHECK-NEXT:                           (basicExprList basics.silt:8:28
--- CHECK-NEXT:                             (namedBasicExpr basics.silt:8:28
--- CHECK-NEXT:                               (qualifiedName basics.silt:8:28
--- CHECK-NEXT:                                 (qualifiedNamePiece basics.silt:8:28
--- CHECK-NEXT:                                   (identifier "B" basics.silt:8:28)))))))
--- CHECK-NEXT:                       (rightParen basics.silt:8:29)))
--- CHECK-NEXT:                   (arrow basics.silt:8:31)
--- CHECK-NEXT:                   (applicationExpr basics.silt:8:34
--- CHECK-NEXT:                     (basicExprList basics.silt:8:34
--- CHECK-NEXT:                       (namedBasicExpr basics.silt:8:34
--- CHECK-NEXT:                         (qualifiedName basics.silt:8:34
--- CHECK-NEXT:                           (qualifiedNamePiece basics.silt:8:34
--- CHECK-NEXT:                             (identifier "C" basics.silt:8:34))))
--- CHECK-NEXT:                       (namedBasicExpr basics.silt:8:36
--- CHECK-NEXT:                         (qualifiedName basics.silt:8:36
--- CHECK-NEXT:                           (qualifiedNamePiece basics.silt:8:36
--- CHECK-NEXT:                             (identifier "x" basics.silt:8:36))))
--- CHECK-NEXT:                       (namedBasicExpr basics.silt:8:38
--- CHECK-NEXT:                         (qualifiedName basics.silt:8:38
--- CHECK-NEXT:                           (qualifiedNamePiece basics.silt:8:38
--- CHECK-NEXT:                             (identifier "y" basics.silt:8:38)))))))
+-- CHECK-NEXT:                 (applicationExpr basics.silt:8:15
+-- CHECK-NEXT:                   (basicExprList basics.silt:8:15
+-- CHECK-NEXT:                     (typedParameterGroupExpr basics.silt:8:15
+-- CHECK-NEXT:                       (typedParameterList basics.silt:8:15
+-- CHECK-NEXT:                         (explicitTypedParameter basics.silt:8:15
+-- CHECK-NEXT:                           (leftParen basics.silt:8:15)
+-- CHECK-NEXT:                           (ascription basics.silt:8:16
+-- CHECK-NEXT:                             (identifierList basics.silt:8:16
+-- CHECK-NEXT:                               (identifier "x" basics.silt:8:16))
+-- CHECK-NEXT:                             (colon basics.silt:8:18)
+-- CHECK-NEXT:                             (applicationExpr basics.silt:8:20
+-- CHECK-NEXT:                               (basicExprList basics.silt:8:20
+-- CHECK-NEXT:                                 (namedBasicExpr basics.silt:8:20
+-- CHECK-NEXT:                                   (qualifiedName basics.silt:8:20
+-- CHECK-NEXT:                                     (qualifiedNamePiece basics.silt:8:20
+-- CHECK-NEXT:                                       (identifier "A" basics.silt:8:20)))))))
+-- CHECK-NEXT:                           (rightParen basics.silt:8:21))
+-- CHECK-NEXT:                         (explicitTypedParameter basics.silt:8:23
+-- CHECK-NEXT:                           (leftParen basics.silt:8:23)
+-- CHECK-NEXT:                           (ascription basics.silt:8:24
+-- CHECK-NEXT:                             (identifierList basics.silt:8:24
+-- CHECK-NEXT:                               (identifier "y" basics.silt:8:24))
+-- CHECK-NEXT:                             (colon basics.silt:8:26)
+-- CHECK-NEXT:                             (applicationExpr basics.silt:8:28
+-- CHECK-NEXT:                               (basicExprList basics.silt:8:28
+-- CHECK-NEXT:                                 (namedBasicExpr basics.silt:8:28
+-- CHECK-NEXT:                                   (qualifiedName basics.silt:8:28
+-- CHECK-NEXT:                                     (qualifiedNamePiece basics.silt:8:28
+-- CHECK-NEXT:                                       (identifier "B" basics.silt:8:28)))))))
+-- CHECK-NEXT:                           (rightParen basics.silt:8:29))))
+-- CHECK-NEXT:                     (namedBasicExpr basics.silt:8:31
+-- CHECK-NEXT:                       (qualifiedName basics.silt:8:31
+-- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:8:31
+-- CHECK-NEXT:                           (arrow basics.silt:8:31))))
+-- CHECK-NEXT:                     (namedBasicExpr basics.silt:8:34
+-- CHECK-NEXT:                       (qualifiedName basics.silt:8:34
+-- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:8:34
+-- CHECK-NEXT:                           (identifier "C" basics.silt:8:34))))
+-- CHECK-NEXT:                     (namedBasicExpr basics.silt:8:36
+-- CHECK-NEXT:                       (qualifiedName basics.silt:8:36
+-- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:8:36
+-- CHECK-NEXT:                           (identifier "x" basics.silt:8:36))))
+-- CHECK-NEXT:                     (namedBasicExpr basics.silt:8:38
+-- CHECK-NEXT:                       (qualifiedName basics.silt:8:38
+-- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:8:38
+-- CHECK-NEXT:                           (identifier "y" basics.silt:8:38))))))
 -- CHECK-NEXT:                 (rightParen basics.silt:8:39))
 -- CHECK-NEXT:               (namedBasicExpr basics.silt:8:41
 -- CHECK-NEXT:                 (qualifiedName basics.silt:8:41
@@ -213,49 +216,52 @@
 -- CHECK-NEXT:                     (arrow basics.silt:8:41))))
 -- CHECK-NEXT:               (parenthesizedExpr basics.silt:8:44
 -- CHECK-NEXT:                 (leftParen basics.silt:8:44)
--- CHECK-NEXT:                 (typedParameterArrowExpr basics.silt:8:45
--- CHECK-NEXT:                   (typedParameterList basics.silt:8:45
--- CHECK-NEXT:                     (explicitTypedParameter basics.silt:8:45
--- CHECK-NEXT:                       (leftParen basics.silt:8:45)
--- CHECK-NEXT:                       (ascription basics.silt:8:46
--- CHECK-NEXT:                         (identifierList basics.silt:8:46
--- CHECK-NEXT:                           (identifier "y" basics.silt:8:46))
--- CHECK-NEXT:                         (colon basics.silt:8:48)
--- CHECK-NEXT:                         (applicationExpr basics.silt:8:50
--- CHECK-NEXT:                           (basicExprList basics.silt:8:50
--- CHECK-NEXT:                             (namedBasicExpr basics.silt:8:50
--- CHECK-NEXT:                               (qualifiedName basics.silt:8:50
--- CHECK-NEXT:                                 (qualifiedNamePiece basics.silt:8:50
--- CHECK-NEXT:                                   (identifier "B" basics.silt:8:50)))))))
--- CHECK-NEXT:                       (rightParen basics.silt:8:51))
--- CHECK-NEXT:                     (explicitTypedParameter basics.silt:8:53
--- CHECK-NEXT:                       (leftParen basics.silt:8:53)
--- CHECK-NEXT:                       (ascription basics.silt:8:54
--- CHECK-NEXT:                         (identifierList basics.silt:8:54
--- CHECK-NEXT:                           (identifier "x" basics.silt:8:54))
--- CHECK-NEXT:                         (colon basics.silt:8:56)
--- CHECK-NEXT:                         (applicationExpr basics.silt:8:58
--- CHECK-NEXT:                           (basicExprList basics.silt:8:58
--- CHECK-NEXT:                             (namedBasicExpr basics.silt:8:58
--- CHECK-NEXT:                               (qualifiedName basics.silt:8:58
--- CHECK-NEXT:                                 (qualifiedNamePiece basics.silt:8:58
--- CHECK-NEXT:                                   (identifier "A" basics.silt:8:58)))))))
--- CHECK-NEXT:                       (rightParen basics.silt:8:59)))
--- CHECK-NEXT:                   (arrow basics.silt:8:61)
--- CHECK-NEXT:                   (applicationExpr basics.silt:8:64
--- CHECK-NEXT:                     (basicExprList basics.silt:8:64
--- CHECK-NEXT:                       (namedBasicExpr basics.silt:8:64
--- CHECK-NEXT:                         (qualifiedName basics.silt:8:64
--- CHECK-NEXT:                           (qualifiedNamePiece basics.silt:8:64
--- CHECK-NEXT:                             (identifier "C" basics.silt:8:64))))
--- CHECK-NEXT:                       (namedBasicExpr basics.silt:8:66
--- CHECK-NEXT:                         (qualifiedName basics.silt:8:66
--- CHECK-NEXT:                           (qualifiedNamePiece basics.silt:8:66
--- CHECK-NEXT:                             (identifier "x" basics.silt:8:66))))
--- CHECK-NEXT:                       (namedBasicExpr basics.silt:8:68
--- CHECK-NEXT:                         (qualifiedName basics.silt:8:68
--- CHECK-NEXT:                           (qualifiedNamePiece basics.silt:8:68
--- CHECK-NEXT:                             (identifier "y" basics.silt:8:68)))))))
+-- CHECK-NEXT:                 (applicationExpr basics.silt:8:45
+-- CHECK-NEXT:                   (basicExprList basics.silt:8:45
+-- CHECK-NEXT:                     (typedParameterGroupExpr basics.silt:8:45
+-- CHECK-NEXT:                       (typedParameterList basics.silt:8:45
+-- CHECK-NEXT:                         (explicitTypedParameter basics.silt:8:45
+-- CHECK-NEXT:                           (leftParen basics.silt:8:45)
+-- CHECK-NEXT:                           (ascription basics.silt:8:46
+-- CHECK-NEXT:                             (identifierList basics.silt:8:46
+-- CHECK-NEXT:                               (identifier "y" basics.silt:8:46))
+-- CHECK-NEXT:                             (colon basics.silt:8:48)
+-- CHECK-NEXT:                             (applicationExpr basics.silt:8:50
+-- CHECK-NEXT:                               (basicExprList basics.silt:8:50
+-- CHECK-NEXT:                                 (namedBasicExpr basics.silt:8:50
+-- CHECK-NEXT:                                   (qualifiedName basics.silt:8:50
+-- CHECK-NEXT:                                     (qualifiedNamePiece basics.silt:8:50
+-- CHECK-NEXT:                                       (identifier "B" basics.silt:8:50)))))))
+-- CHECK-NEXT:                           (rightParen basics.silt:8:51))
+-- CHECK-NEXT:                         (explicitTypedParameter basics.silt:8:53
+-- CHECK-NEXT:                           (leftParen basics.silt:8:53)
+-- CHECK-NEXT:                           (ascription basics.silt:8:54
+-- CHECK-NEXT:                             (identifierList basics.silt:8:54
+-- CHECK-NEXT:                               (identifier "x" basics.silt:8:54))
+-- CHECK-NEXT:                             (colon basics.silt:8:56)
+-- CHECK-NEXT:                             (applicationExpr basics.silt:8:58
+-- CHECK-NEXT:                               (basicExprList basics.silt:8:58
+-- CHECK-NEXT:                                 (namedBasicExpr basics.silt:8:58
+-- CHECK-NEXT:                                   (qualifiedName basics.silt:8:58
+-- CHECK-NEXT:                                     (qualifiedNamePiece basics.silt:8:58
+-- CHECK-NEXT:                                       (identifier "A" basics.silt:8:58)))))))
+-- CHECK-NEXT:                           (rightParen basics.silt:8:59))))
+-- CHECK-NEXT:                     (namedBasicExpr basics.silt:8:61
+-- CHECK-NEXT:                       (qualifiedName basics.silt:8:61
+-- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:8:61
+-- CHECK-NEXT:                           (arrow basics.silt:8:61))))
+-- CHECK-NEXT:                     (namedBasicExpr basics.silt:8:64
+-- CHECK-NEXT:                       (qualifiedName basics.silt:8:64
+-- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:8:64
+-- CHECK-NEXT:                           (identifier "C" basics.silt:8:64))))
+-- CHECK-NEXT:                     (namedBasicExpr basics.silt:8:66
+-- CHECK-NEXT:                       (qualifiedName basics.silt:8:66
+-- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:8:66
+-- CHECK-NEXT:                           (identifier "x" basics.silt:8:66))))
+-- CHECK-NEXT:                     (namedBasicExpr basics.silt:8:68
+-- CHECK-NEXT:                       (qualifiedName basics.silt:8:68
+-- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:8:68
+-- CHECK-NEXT:                           (identifier "y" basics.silt:8:68))))))
 -- CHECK-NEXT:                 (rightParen basics.silt:8:69)))))))
 -- CHECK-NEXT:     (normalFunctionClauseDecl basics.silt:9:0
 -- CHECK-NEXT:       (basicExprList basics.silt:9:0
@@ -361,127 +367,141 @@
 -- CHECK-NEXT:                 (identifierList basics.silt:12:43
 -- CHECK-NEXT:                   (identifier "C" basics.silt:12:43))
 -- CHECK-NEXT:                 (colon basics.silt:12:45)
--- CHECK-NEXT:                 (typedParameterArrowExpr basics.silt:12:47
--- CHECK-NEXT:                   (typedParameterList basics.silt:12:47
--- CHECK-NEXT:                     (explicitTypedParameter basics.silt:12:47
--- CHECK-NEXT:                       (leftParen basics.silt:12:47)
--- CHECK-NEXT:                       (ascription basics.silt:12:48
--- CHECK-NEXT:                         (identifierList basics.silt:12:48
--- CHECK-NEXT:                           (identifier "a" basics.silt:12:48))
--- CHECK-NEXT:                         (colon basics.silt:12:50)
--- CHECK-NEXT:                         (applicationExpr basics.silt:12:52
--- CHECK-NEXT:                           (basicExprList basics.silt:12:52
--- CHECK-NEXT:                             (namedBasicExpr basics.silt:12:52
--- CHECK-NEXT:                               (qualifiedName basics.silt:12:52
--- CHECK-NEXT:                                 (qualifiedNamePiece basics.silt:12:52
--- CHECK-NEXT:                                   (identifier "A" basics.silt:12:52)))))))
--- CHECK-NEXT:                       (rightParen basics.silt:12:53)))
--- CHECK-NEXT:                   (arrow basics.silt:12:55)
--- CHECK-NEXT:                   (applicationExpr basics.silt:12:58
--- CHECK-NEXT:                     (basicExprList basics.silt:12:58
--- CHECK-NEXT:                       (namedBasicExpr basics.silt:12:58
--- CHECK-NEXT:                         (qualifiedName basics.silt:12:58
--- CHECK-NEXT:                           (qualifiedNamePiece basics.silt:12:58
--- CHECK-NEXT:                             (identifier "B" basics.silt:12:58))))
--- CHECK-NEXT:                       (namedBasicExpr basics.silt:12:60
--- CHECK-NEXT:                         (qualifiedName basics.silt:12:60
--- CHECK-NEXT:                           (qualifiedNamePiece basics.silt:12:60
--- CHECK-NEXT:                             (identifier "a" basics.silt:12:60))))
--- CHECK-NEXT:                       (namedBasicExpr basics.silt:12:62
--- CHECK-NEXT:                         (qualifiedName basics.silt:12:62
--- CHECK-NEXT:                           (qualifiedNamePiece basics.silt:12:62
--- CHECK-NEXT:                             (arrow basics.silt:12:62))))
--- CHECK-NEXT:                       (typeBasicExpr basics.silt:12:65
--- CHECK-NEXT:                         (typeKeyword basics.silt:12:65))
--- CHECK-NEXT:                       (namedBasicExpr basics.silt:12:70
--- CHECK-NEXT:                         (qualifiedName basics.silt:12:70
--- CHECK-NEXT:                           (qualifiedNamePiece basics.silt:12:70
--- CHECK-NEXT:                             (identifier "k" basics.silt:12:70))))))))
+-- CHECK-NEXT:                 (applicationExpr basics.silt:12:47
+-- CHECK-NEXT:                   (basicExprList basics.silt:12:47
+-- CHECK-NEXT:                     (typedParameterGroupExpr basics.silt:12:47
+-- CHECK-NEXT:                       (typedParameterList basics.silt:12:47
+-- CHECK-NEXT:                         (explicitTypedParameter basics.silt:12:47
+-- CHECK-NEXT:                           (leftParen basics.silt:12:47)
+-- CHECK-NEXT:                           (ascription basics.silt:12:48
+-- CHECK-NEXT:                             (identifierList basics.silt:12:48
+-- CHECK-NEXT:                               (identifier "a" basics.silt:12:48))
+-- CHECK-NEXT:                             (colon basics.silt:12:50)
+-- CHECK-NEXT:                             (applicationExpr basics.silt:12:52
+-- CHECK-NEXT:                               (basicExprList basics.silt:12:52
+-- CHECK-NEXT:                                 (namedBasicExpr basics.silt:12:52
+-- CHECK-NEXT:                                   (qualifiedName basics.silt:12:52
+-- CHECK-NEXT:                                     (qualifiedNamePiece basics.silt:12:52
+-- CHECK-NEXT:                                       (identifier "A" basics.silt:12:52)))))))
+-- CHECK-NEXT:                           (rightParen basics.silt:12:53))))
+-- CHECK-NEXT:                     (namedBasicExpr basics.silt:12:55
+-- CHECK-NEXT:                       (qualifiedName basics.silt:12:55
+-- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:12:55
+-- CHECK-NEXT:                           (arrow basics.silt:12:55))))
+-- CHECK-NEXT:                     (namedBasicExpr basics.silt:12:58
+-- CHECK-NEXT:                       (qualifiedName basics.silt:12:58
+-- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:12:58
+-- CHECK-NEXT:                           (identifier "B" basics.silt:12:58))))
+-- CHECK-NEXT:                     (namedBasicExpr basics.silt:12:60
+-- CHECK-NEXT:                       (qualifiedName basics.silt:12:60
+-- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:12:60
+-- CHECK-NEXT:                           (identifier "a" basics.silt:12:60))))
+-- CHECK-NEXT:                     (namedBasicExpr basics.silt:12:62
+-- CHECK-NEXT:                       (qualifiedName basics.silt:12:62
+-- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:12:62
+-- CHECK-NEXT:                           (arrow basics.silt:12:62))))
+-- CHECK-NEXT:                     (typeBasicExpr basics.silt:12:65
+-- CHECK-NEXT:                       (typeKeyword basics.silt:12:65))
+-- CHECK-NEXT:                     (namedBasicExpr basics.silt:12:70
+-- CHECK-NEXT:                       (qualifiedName basics.silt:12:70
+-- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:12:70
+-- CHECK-NEXT:                           (identifier "k" basics.silt:12:70)))))))
 -- CHECK-NEXT:               (rightBrace basics.silt:12:71)))
 -- CHECK-NEXT:           (arrow basics.silt:12:73)
--- CHECK-NEXT:           (typedParameterArrowExpr basics.silt:13:13
--- CHECK-NEXT:             (typedParameterList basics.silt:13:13
--- CHECK-NEXT:               (explicitTypedParameter basics.silt:13:13
--- CHECK-NEXT:                 (leftParen basics.silt:13:13)
--- CHECK-NEXT:                 (ascription basics.silt:13:14
--- CHECK-NEXT:                   (identifierList basics.silt:13:14
--- CHECK-NEXT:                     (identifier "f" basics.silt:13:14))
--- CHECK-NEXT:                   (colon basics.silt:13:16)
--- CHECK-NEXT:                   (typedParameterArrowExpr basics.silt:13:18
--- CHECK-NEXT:                     (typedParameterList basics.silt:13:18
--- CHECK-NEXT:                       (implicitTypedParameter basics.silt:13:18
--- CHECK-NEXT:                         (leftBrace basics.silt:13:18)
--- CHECK-NEXT:                         (ascription basics.silt:13:19
--- CHECK-NEXT:                           (identifierList basics.silt:13:19
--- CHECK-NEXT:                             (identifier "a" basics.silt:13:19))
--- CHECK-NEXT:                           (colon basics.silt:13:21)
--- CHECK-NEXT:                           (applicationExpr basics.silt:13:23
--- CHECK-NEXT:                             (basicExprList basics.silt:13:23
--- CHECK-NEXT:                               (namedBasicExpr basics.silt:13:23
--- CHECK-NEXT:                                 (qualifiedName basics.silt:13:23
--- CHECK-NEXT:                                   (qualifiedNamePiece basics.silt:13:23
--- CHECK-NEXT:                                     (identifier "A" basics.silt:13:23)))))))
--- CHECK-NEXT:                         (rightBrace basics.silt:13:24))
--- CHECK-NEXT:                       (explicitTypedParameter basics.silt:13:25
--- CHECK-NEXT:                         (leftParen basics.silt:13:25)
--- CHECK-NEXT:                         (ascription basics.silt:13:26
--- CHECK-NEXT:                           (identifierList basics.silt:13:26
--- CHECK-NEXT:                             (identifier "b" basics.silt:13:26))
--- CHECK-NEXT:                           (colon basics.silt:13:28)
--- CHECK-NEXT:                           (applicationExpr basics.silt:13:30
--- CHECK-NEXT:                             (basicExprList basics.silt:13:30
--- CHECK-NEXT:                               (namedBasicExpr basics.silt:13:30
--- CHECK-NEXT:                                 (qualifiedName basics.silt:13:30
--- CHECK-NEXT:                                   (qualifiedNamePiece basics.silt:13:30
--- CHECK-NEXT:                                     (identifier "B" basics.silt:13:30))))
--- CHECK-NEXT:                               (namedBasicExpr basics.silt:13:32
--- CHECK-NEXT:                                 (qualifiedName basics.silt:13:32
--- CHECK-NEXT:                                   (qualifiedNamePiece basics.silt:13:32
--- CHECK-NEXT:                                     (identifier "a" basics.silt:13:32)))))))
--- CHECK-NEXT:                         (rightParen basics.silt:13:33)))
--- CHECK-NEXT:                     (arrow basics.silt:13:35)
--- CHECK-NEXT:                     (applicationExpr basics.silt:13:38
--- CHECK-NEXT:                       (basicExprList basics.silt:13:38
--- CHECK-NEXT:                         (namedBasicExpr basics.silt:13:38
--- CHECK-NEXT:                           (qualifiedName basics.silt:13:38
--- CHECK-NEXT:                             (qualifiedNamePiece basics.silt:13:38
--- CHECK-NEXT:                               (identifier "C" basics.silt:13:38))))
--- CHECK-NEXT:                         (namedBasicExpr basics.silt:13:40
--- CHECK-NEXT:                           (qualifiedName basics.silt:13:40
--- CHECK-NEXT:                             (qualifiedNamePiece basics.silt:13:40
--- CHECK-NEXT:                               (identifier "a" basics.silt:13:40))))
--- CHECK-NEXT:                         (namedBasicExpr basics.silt:13:42
--- CHECK-NEXT:                           (qualifiedName basics.silt:13:42
--- CHECK-NEXT:                             (qualifiedNamePiece basics.silt:13:42
--- CHECK-NEXT:                               (identifier "b" basics.silt:13:42))))))))
--- CHECK-NEXT:                 (rightParen basics.silt:13:43)))
--- CHECK-NEXT:             (arrow basics.silt:13:45)
--- CHECK-NEXT:             (typedParameterArrowExpr basics.silt:14:13
--- CHECK-NEXT:               (typedParameterList basics.silt:14:13
--- CHECK-NEXT:                 (explicitTypedParameter basics.silt:14:13
--- CHECK-NEXT:                   (leftParen basics.silt:14:13)
--- CHECK-NEXT:                   (ascription basics.silt:14:14
--- CHECK-NEXT:                     (identifierList basics.silt:14:14
--- CHECK-NEXT:                       (identifier "g" basics.silt:14:14))
--- CHECK-NEXT:                     (colon basics.silt:14:16)
--- CHECK-NEXT:                     (typedParameterArrowExpr basics.silt:14:18
--- CHECK-NEXT:                       (typedParameterList basics.silt:14:18
--- CHECK-NEXT:                         (explicitTypedParameter basics.silt:14:18
--- CHECK-NEXT:                           (leftParen basics.silt:14:18)
--- CHECK-NEXT:                           (ascription basics.silt:14:19
--- CHECK-NEXT:                             (identifierList basics.silt:14:19
--- CHECK-NEXT:                               (identifier "a" basics.silt:14:19))
--- CHECK-NEXT:                             (colon basics.silt:14:21)
--- CHECK-NEXT:                             (applicationExpr basics.silt:14:23
--- CHECK-NEXT:                               (basicExprList basics.silt:14:23
--- CHECK-NEXT:                                 (namedBasicExpr basics.silt:14:23
--- CHECK-NEXT:                                   (qualifiedName basics.silt:14:23
--- CHECK-NEXT:                                     (qualifiedNamePiece basics.silt:14:23
--- CHECK-NEXT:                                       (identifier "A" basics.silt:14:23)))))))
--- CHECK-NEXT:                           (rightParen basics.silt:14:24)))
--- CHECK-NEXT:                       (arrow basics.silt:14:26)
--- CHECK-NEXT:                       (applicationExpr basics.silt:14:29
--- CHECK-NEXT:                         (basicExprList basics.silt:14:29
+-- CHECK-NEXT:           (applicationExpr basics.silt:13:13
+-- CHECK-NEXT:             (basicExprList basics.silt:13:13
+-- CHECK-NEXT:               (typedParameterGroupExpr basics.silt:13:13
+-- CHECK-NEXT:                 (typedParameterList basics.silt:13:13
+-- CHECK-NEXT:                   (explicitTypedParameter basics.silt:13:13
+-- CHECK-NEXT:                     (leftParen basics.silt:13:13)
+-- CHECK-NEXT:                     (ascription basics.silt:13:14
+-- CHECK-NEXT:                       (identifierList basics.silt:13:14
+-- CHECK-NEXT:                         (identifier "f" basics.silt:13:14))
+-- CHECK-NEXT:                       (colon basics.silt:13:16)
+-- CHECK-NEXT:                       (applicationExpr basics.silt:13:18
+-- CHECK-NEXT:                         (basicExprList basics.silt:13:18
+-- CHECK-NEXT:                           (typedParameterGroupExpr basics.silt:13:18
+-- CHECK-NEXT:                             (typedParameterList basics.silt:13:18
+-- CHECK-NEXT:                               (implicitTypedParameter basics.silt:13:18
+-- CHECK-NEXT:                                 (leftBrace basics.silt:13:18)
+-- CHECK-NEXT:                                 (ascription basics.silt:13:19
+-- CHECK-NEXT:                                   (identifierList basics.silt:13:19
+-- CHECK-NEXT:                                     (identifier "a" basics.silt:13:19))
+-- CHECK-NEXT:                                   (colon basics.silt:13:21)
+-- CHECK-NEXT:                                   (applicationExpr basics.silt:13:23
+-- CHECK-NEXT:                                     (basicExprList basics.silt:13:23
+-- CHECK-NEXT:                                       (namedBasicExpr basics.silt:13:23
+-- CHECK-NEXT:                                         (qualifiedName basics.silt:13:23
+-- CHECK-NEXT:                                           (qualifiedNamePiece basics.silt:13:23
+-- CHECK-NEXT:                                             (identifier "A" basics.silt:13:23)))))))
+-- CHECK-NEXT:                                 (rightBrace basics.silt:13:24))
+-- CHECK-NEXT:                               (explicitTypedParameter basics.silt:13:25
+-- CHECK-NEXT:                                 (leftParen basics.silt:13:25)
+-- CHECK-NEXT:                                 (ascription basics.silt:13:26
+-- CHECK-NEXT:                                   (identifierList basics.silt:13:26
+-- CHECK-NEXT:                                     (identifier "b" basics.silt:13:26))
+-- CHECK-NEXT:                                   (colon basics.silt:13:28)
+-- CHECK-NEXT:                                   (applicationExpr basics.silt:13:30
+-- CHECK-NEXT:                                     (basicExprList basics.silt:13:30
+-- CHECK-NEXT:                                       (namedBasicExpr basics.silt:13:30
+-- CHECK-NEXT:                                         (qualifiedName basics.silt:13:30
+-- CHECK-NEXT:                                           (qualifiedNamePiece basics.silt:13:30
+-- CHECK-NEXT:                                             (identifier "B" basics.silt:13:30))))
+-- CHECK-NEXT:                                       (namedBasicExpr basics.silt:13:32
+-- CHECK-NEXT:                                         (qualifiedName basics.silt:13:32
+-- CHECK-NEXT:                                           (qualifiedNamePiece basics.silt:13:32
+-- CHECK-NEXT:                                             (identifier "a" basics.silt:13:32)))))))
+-- CHECK-NEXT:                                 (rightParen basics.silt:13:33))))
+-- CHECK-NEXT:                           (namedBasicExpr basics.silt:13:35
+-- CHECK-NEXT:                             (qualifiedName basics.silt:13:35
+-- CHECK-NEXT:                               (qualifiedNamePiece basics.silt:13:35
+-- CHECK-NEXT:                                 (arrow basics.silt:13:35))))
+-- CHECK-NEXT:                           (namedBasicExpr basics.silt:13:38
+-- CHECK-NEXT:                             (qualifiedName basics.silt:13:38
+-- CHECK-NEXT:                               (qualifiedNamePiece basics.silt:13:38
+-- CHECK-NEXT:                                 (identifier "C" basics.silt:13:38))))
+-- CHECK-NEXT:                           (namedBasicExpr basics.silt:13:40
+-- CHECK-NEXT:                             (qualifiedName basics.silt:13:40
+-- CHECK-NEXT:                               (qualifiedNamePiece basics.silt:13:40
+-- CHECK-NEXT:                                 (identifier "a" basics.silt:13:40))))
+-- CHECK-NEXT:                           (namedBasicExpr basics.silt:13:42
+-- CHECK-NEXT:                             (qualifiedName basics.silt:13:42
+-- CHECK-NEXT:                               (qualifiedNamePiece basics.silt:13:42
+-- CHECK-NEXT:                                 (identifier "b" basics.silt:13:42)))))))
+-- CHECK-NEXT:                     (rightParen basics.silt:13:43))))
+-- CHECK-NEXT:               (namedBasicExpr basics.silt:13:45
+-- CHECK-NEXT:                 (qualifiedName basics.silt:13:45
+-- CHECK-NEXT:                   (qualifiedNamePiece basics.silt:13:45
+-- CHECK-NEXT:                     (arrow basics.silt:13:45))))
+-- CHECK-NEXT:               (typedParameterGroupExpr basics.silt:14:13
+-- CHECK-NEXT:                 (typedParameterList basics.silt:14:13
+-- CHECK-NEXT:                   (explicitTypedParameter basics.silt:14:13
+-- CHECK-NEXT:                     (leftParen basics.silt:14:13)
+-- CHECK-NEXT:                     (ascription basics.silt:14:14
+-- CHECK-NEXT:                       (identifierList basics.silt:14:14
+-- CHECK-NEXT:                         (identifier "g" basics.silt:14:14))
+-- CHECK-NEXT:                       (colon basics.silt:14:16)
+-- CHECK-NEXT:                       (applicationExpr basics.silt:14:18
+-- CHECK-NEXT:                         (basicExprList basics.silt:14:18
+-- CHECK-NEXT:                           (typedParameterGroupExpr basics.silt:14:18
+-- CHECK-NEXT:                             (typedParameterList basics.silt:14:18
+-- CHECK-NEXT:                               (explicitTypedParameter basics.silt:14:18
+-- CHECK-NEXT:                                 (leftParen basics.silt:14:18)
+-- CHECK-NEXT:                                 (ascription basics.silt:14:19
+-- CHECK-NEXT:                                   (identifierList basics.silt:14:19
+-- CHECK-NEXT:                                     (identifier "a" basics.silt:14:19))
+-- CHECK-NEXT:                                   (colon basics.silt:14:21)
+-- CHECK-NEXT:                                   (applicationExpr basics.silt:14:23
+-- CHECK-NEXT:                                     (basicExprList basics.silt:14:23
+-- CHECK-NEXT:                                       (namedBasicExpr basics.silt:14:23
+-- CHECK-NEXT:                                         (qualifiedName basics.silt:14:23
+-- CHECK-NEXT:                                           (qualifiedNamePiece basics.silt:14:23
+-- CHECK-NEXT:                                             (identifier "A" basics.silt:14:23)))))))
+-- CHECK-NEXT:                                 (rightParen basics.silt:14:24))))
+-- CHECK-NEXT:                           (namedBasicExpr basics.silt:14:26
+-- CHECK-NEXT:                             (qualifiedName basics.silt:14:26
+-- CHECK-NEXT:                               (qualifiedNamePiece basics.silt:14:26
+-- CHECK-NEXT:                                 (arrow basics.silt:14:26))))
 -- CHECK-NEXT:                           (namedBasicExpr basics.silt:14:29
 -- CHECK-NEXT:                             (qualifiedName basics.silt:14:29
 -- CHECK-NEXT:                               (qualifiedNamePiece basics.silt:14:29
@@ -489,10 +509,13 @@
 -- CHECK-NEXT:                           (namedBasicExpr basics.silt:14:31
 -- CHECK-NEXT:                             (qualifiedName basics.silt:14:31
 -- CHECK-NEXT:                               (qualifiedNamePiece basics.silt:14:31
--- CHECK-NEXT:                                 (identifier "a" basics.silt:14:31))))))))
--- CHECK-NEXT:                   (rightParen basics.silt:14:32)))
--- CHECK-NEXT:               (arrow basics.silt:14:34)
--- CHECK-NEXT:               (typedParameterArrowExpr basics.silt:15:13
+-- CHECK-NEXT:                                 (identifier "a" basics.silt:14:31)))))))
+-- CHECK-NEXT:                     (rightParen basics.silt:14:32))))
+-- CHECK-NEXT:               (namedBasicExpr basics.silt:14:34
+-- CHECK-NEXT:                 (qualifiedName basics.silt:14:34
+-- CHECK-NEXT:                   (qualifiedNamePiece basics.silt:14:34
+-- CHECK-NEXT:                     (arrow basics.silt:14:34))))
+-- CHECK-NEXT:               (typedParameterGroupExpr basics.silt:15:13
 -- CHECK-NEXT:                 (typedParameterList basics.silt:15:13
 -- CHECK-NEXT:                   (explicitTypedParameter basics.silt:15:13
 -- CHECK-NEXT:                     (leftParen basics.silt:15:13)
@@ -506,31 +529,32 @@
 -- CHECK-NEXT:                             (qualifiedName basics.silt:15:18
 -- CHECK-NEXT:                               (qualifiedNamePiece basics.silt:15:18
 -- CHECK-NEXT:                                 (identifier "A" basics.silt:15:18)))))))
--- CHECK-NEXT:                     (rightParen basics.silt:15:19)))
--- CHECK-NEXT:                 (arrow basics.silt:15:21)
--- CHECK-NEXT:                 (applicationExpr basics.silt:15:24
--- CHECK-NEXT:                   (basicExprList basics.silt:15:24
--- CHECK-NEXT:                     (namedBasicExpr basics.silt:15:24
--- CHECK-NEXT:                       (qualifiedName basics.silt:15:24
--- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:15:24
--- CHECK-NEXT:                           (identifier "C" basics.silt:15:24))))
--- CHECK-NEXT:                     (namedBasicExpr basics.silt:15:26
--- CHECK-NEXT:                       (qualifiedName basics.silt:15:26
--- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:15:26
--- CHECK-NEXT:                           (identifier "a" basics.silt:15:26))))
--- CHECK-NEXT:                     (parenthesizedExpr basics.silt:15:28
--- CHECK-NEXT:                       (leftParen basics.silt:15:28)
--- CHECK-NEXT:                       (applicationExpr basics.silt:15:29
--- CHECK-NEXT:                         (basicExprList basics.silt:15:29
--- CHECK-NEXT:                           (namedBasicExpr basics.silt:15:29
--- CHECK-NEXT:                             (qualifiedName basics.silt:15:29
--- CHECK-NEXT:                               (qualifiedNamePiece basics.silt:15:29
--- CHECK-NEXT:                                 (identifier "g" basics.silt:15:29))))
--- CHECK-NEXT:                           (namedBasicExpr basics.silt:15:31
--- CHECK-NEXT:                             (qualifiedName basics.silt:15:31
--- CHECK-NEXT:                               (qualifiedNamePiece basics.silt:15:31
--- CHECK-NEXT:                                 (identifier "a" basics.silt:15:31))))))
--- CHECK-NEXT:                       (rightParen basics.silt:15:32))))))))))
+-- CHECK-NEXT:                     (rightParen basics.silt:15:19))))
+-- CHECK-NEXT:               (namedBasicExpr basics.silt:15:21
+-- CHECK-NEXT:                 (qualifiedName basics.silt:15:21
+-- CHECK-NEXT:                   (qualifiedNamePiece basics.silt:15:21
+-- CHECK-NEXT:                     (arrow basics.silt:15:21))))
+-- CHECK-NEXT:               (namedBasicExpr basics.silt:15:24
+-- CHECK-NEXT:                 (qualifiedName basics.silt:15:24
+-- CHECK-NEXT:                   (qualifiedNamePiece basics.silt:15:24
+-- CHECK-NEXT:                     (identifier "C" basics.silt:15:24))))
+-- CHECK-NEXT:               (namedBasicExpr basics.silt:15:26
+-- CHECK-NEXT:                 (qualifiedName basics.silt:15:26
+-- CHECK-NEXT:                   (qualifiedNamePiece basics.silt:15:26
+-- CHECK-NEXT:                     (identifier "a" basics.silt:15:26))))
+-- CHECK-NEXT:               (parenthesizedExpr basics.silt:15:28
+-- CHECK-NEXT:                 (leftParen basics.silt:15:28)
+-- CHECK-NEXT:                 (applicationExpr basics.silt:15:29
+-- CHECK-NEXT:                   (basicExprList basics.silt:15:29
+-- CHECK-NEXT:                     (namedBasicExpr basics.silt:15:29
+-- CHECK-NEXT:                       (qualifiedName basics.silt:15:29
+-- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:15:29
+-- CHECK-NEXT:                           (identifier "g" basics.silt:15:29))))
+-- CHECK-NEXT:                     (namedBasicExpr basics.silt:15:31
+-- CHECK-NEXT:                       (qualifiedName basics.silt:15:31
+-- CHECK-NEXT:                         (qualifiedNamePiece basics.silt:15:31
+-- CHECK-NEXT:                           (identifier "a" basics.silt:15:31))))))
+-- CHECK-NEXT:                 (rightParen basics.silt:15:32)))))))
 -- CHECK-NEXT:     (normalFunctionClauseDecl basics.silt:16:0
 -- CHECK-NEXT:       (basicExprList basics.silt:16:0
 -- CHECK-NEXT:         (namedBasicExpr basics.silt:16:0

--- a/Tests/SyntaxTests/Resources/datatypes.silt.ast
+++ b/Tests/SyntaxTests/Resources/datatypes.silt.ast
@@ -61,7 +61,7 @@
 -- CHECK-NEXT:            (typeBasicExpr datatypes.silt:7:16
 -- CHECK-NEXT:              (typeKeyword datatypes.silt:7:16)))))
 -- CHECK-NEXT:      (whereKeyword datatypes.silt:7:21)
--- CHECK-NEXT:      (recordElementList datatypes.silt:8:2
+-- CHECK-NEXT:      (declList datatypes.silt:8:2
 -- CHECK-NEXT:        (recordConstructorDecl datatypes.silt:8:2
 -- CHECK-NEXT:          (constructorKeyword datatypes.silt:8:2)
 -- CHECK-NEXT:          (identifier "MkPerson" datatypes.silt:8:14))


### PR DESCRIPTION
- Collapse SyntaxCollection subclasses into typealiases:

SyntaxGen now synthesizes a dictionary of `ObjectIdentifier`s mapping collection element archetypes to syntax kinds.  This now means that

1) It is no longer possible to declare two SyntaxCollections containing the same element type with different element types.  (I think this restriction can be lifted with some creativity).
2) SyntaxCollection's mutating functions can be used without consequence.

- Break ambiguity in parsing parenthesized expressions

Fixes #49 by removing the special case for arrow-containing parameter lists.  Instead, parse the parameter part as a basic expression and the arrow part and output part as an application expression like everything else.