### PR TITLE
Fix multiple scoping issues

### DIFF
--- a/Sources/Moho/NameBinding.swift
+++ b/Sources/Moho/NameBinding.swift
@@ -341,8 +341,10 @@ extension NameBinding {
   }
 
   private func checkNotShadowing(_ n: Name) -> Bool {
-    if self.activeScope.vars[n] != nil {
-      engine.diagnose(.nameShadows(n))
+    if let synNode = self.activeScope.vars[n] {
+      engine.diagnose(.nameShadows(n), node: synNode) {
+        $0.note(.shadowsOriginal(n))
+      }
       return false
     }
     if let (qn, _) = self.lookupLocalName(n) {

--- a/Sources/Moho/ScopeDiagnostics.swift
+++ b/Sources/Moho/ScopeDiagnostics.swift
@@ -32,10 +32,14 @@ extension Diagnostic.Message {
     return Diagnostic.Message(.error, "cannot shadow name '\(n)'")
   }
 
+  static func shadowsOriginal(_ n: Name) -> Diagnostic.Message {
+    return Diagnostic.Message(.note, "first declaration of '\(n)' occurs here")
+  }
+
   static func nameShadows(
     _ local: Name, _ n: FullyQualifiedName) -> Diagnostic.Message {
     return Diagnostic.Message(.error,
-      "name '\(local)' shadows shadow qualified '\(n)'")
+      "name '\(local)' shadows qualified '\(n)'")
   }
 
   static func duplicateImport(_ qn: QualifiedName) -> Diagnostic.Message {

--- a/Tests/Lite/ScopeCheck/bad-scope.silt
+++ b/Tests/Lite/ScopeCheck/bad-scope.silt
@@ -2,7 +2,7 @@
 
 module bad-scope where
 
-id : forall {A : Type} -> A -> A
+id : forall {A : Type} -> A -> A -- expected-note {{first declaration of 'id' occurs here}}
 id x = y -- expected-error {{use of undeclared identifier 'y'}}
 
 id : forall {A : Type} -> A -> A -- expected-error {{cannot shadow name 'id'}}
@@ -22,6 +22,14 @@ body-before-sig x = x -- expected-error {{function body for 'body-before-sig' mu
 shadowing-binding : forall {A A : Type} -- expected-error {{cannot shadow name 'A'}}
                            {x x : A} -> x -- expected-error {{cannot shadow name 'x'}}
 shadowing-binding x = x
+
+bad-var : {A : Type} -> A -> A
+bad-var = \ x -> y --expected-error{{use of undeclared identifier 'y'}}
+
+bad-lambdas : {A : Type} -> A -> A -> A
+bad-lambdas = \ x -> (\ y -> (a w))
+--expected-error @-1 {{use of undeclared identifier 'a'}}
+--expected-error @-2 {{use of undeclared identifier 'w'}}
 
 data BadNat : Typo where -- expected-error {{use of undeclared identifier 'Typo'}}
   | z : BadNat


### PR DESCRIPTION
- Check ascription parameters under a new scope
- Improve shadowing diagnostic with note pointing to original
declaration.
- Teach the verifier to search notes
