### PR TITLE
[DiagnosticVerifier] Ensure Unexpected notes are reported during verification

### DIFF
--- a/Tests/Lite/Lite/test-notes.silt
+++ b/Tests/Lite/Lite/test-notes.silt
@@ -1,0 +1,12 @@
+-- RUN-NOT: --verify scopes
+
+module TestNotes where
+
+-- this note should appear: first declaration of 'id' occurs here
+-- this test ensures that the verifier will fail if an unexpected note is
+-- produced
+id : forall {A : Type} -> A -> A
+id x = y -- expected-error {{use of undeclared identifier 'y'}}
+
+id : forall {A : Type} -> A -> A -- expected-error {{cannot shadow name 'id'}}
+id x = x


### PR DESCRIPTION
### What's in this pull request?

Previously, the diagnostic verifier would not report unexpected notes. This change gives it the ability to verify notes by destructing both diagnostics and notes into `(Message, Syntax?)` pairs. This should be purely additive.

### Why merge this pull request?

It should have existed in the original implementation.

### What's worth discussing about this pull request?

Not much.

### What downsides are there to merging this pull request?

None.