### PR TITLE
Improve handling of qualified names

### DIFF
--- a/Sources/Lithosphere/RawSyntax.swift
+++ b/Sources/Lithosphere/RawSyntax.swift
@@ -139,23 +139,28 @@ extension RawSyntax {
   /// Prints the RawSyntax node, and all of its children, to the provided
   /// stream. This implementation must be source-accurate.
   /// - Parameter stream: The stream on which to output this node.
-  func writeSourceText<Target: TextOutputStream>(to target: inout Target,
-                                                 includeImplicit: Bool) {
+  func writeSourceText<Target: TextOutputStream>(
+    to target: inout Target, includeImplicit: Bool, includeTrivia: Bool) {
     switch self {
     case .node(_, let layout, _):
       for child in layout {
-        child.writeSourceText(to: &target, includeImplicit: includeImplicit)
+        child.writeSourceText(to: &target, includeImplicit: includeImplicit,
+                              includeTrivia: includeTrivia)
       }
     case let .token(kind, leadingTrivia, trailingTrivia, presence, _):
       switch presence {
       case .present,
            .implicit where includeImplicit:
-        for piece in leadingTrivia {
-          piece.writeSourceText(to: &target)
+        if includeTrivia {
+          for piece in leadingTrivia {
+            piece.writeSourceText(to: &target)
+          }
         }
         target.write(kind.text)
-        for piece in trailingTrivia {
-          piece.writeSourceText(to: &target)
+        if includeTrivia {
+          for piece in trailingTrivia {
+            piece.writeSourceText(to: &target)
+          }
         }
       default: break
       }

--- a/Sources/Lithosphere/Syntax.swift
+++ b/Sources/Lithosphere/Syntax.swift
@@ -144,13 +144,22 @@ public class Syntax {
     self.writeSourceText(to: &s, includeImplicit: true)
     return s
   }
+
+  public var triviaFreeSourceText: String {
+    var s = ""
+    self.writeSourceText(to: &s, includeImplicit: false, includeTrivia: false)
+    return s
+  }
 }
 
 extension Syntax {
   /// Prints the raw value of this node to the provided stream.
   /// - Parameter stream: The stream to which to print the raw tree.
-  public func writeSourceText<Target: TextOutputStream>(to target: inout Target, includeImplicit: Bool) {
-    data.raw.writeSourceText(to: &target, includeImplicit: includeImplicit)
+  public func writeSourceText<Target: TextOutputStream>(
+    to target: inout Target, includeImplicit: Bool,
+    includeTrivia: Bool = true) {
+    data.raw.writeSourceText(to: &target, includeImplicit: includeImplicit,
+                             includeTrivia: includeTrivia)
   }
 }
 

--- a/Tests/Lite/Parse/ambiguous-parens.silt
+++ b/Tests/Lite/Parse/ambiguous-parens.silt
@@ -6,3 +6,6 @@ module ambiguous-parens where
 -- parameter list.
 foo a b c = (a b c)
 
+-- This should parse just fine
+bar a b c = (M.a M.b (\x -> M.c))
+

--- a/Tests/Lite/Parse/invalid-parameters.silt
+++ b/Tests/Lite/Parse/invalid-parameters.silt
@@ -1,0 +1,6 @@
+-- RUN: --verify parse
+
+module InvalidParameters where
+
+foo : {A.x : Type} -> A -> A --expected-error{{qualified name 'A.x' is not allowed in this position}}
+foo x = x


### PR DESCRIPTION

### What's in this pull request?

- Diagnose qualified names in parameter position (i.e. when parsing an
identifier list)
- Handle qualified names while parsing basic expressions.

### Why merge this pull request?

Previously the parser fell over when faced with a qualified name in parameter postion:

```agda
error: unexpected token '.' (expected ':')
foo : {A.x : Type}
        ^
```

Now, we parse qualified names even when we expect a list of identifiers, so we can go through after the fact and diagnose qualified names.

If the stuff was a valid list of identifiers, then we're fine. 😄

This patch also fixes broken behavior when parsing a parenthesized application involving a qualified name, which *needs* to be fixed.

```agda
error: unexpected token '.' (expected ')')
foo x = (M.x a b)
          ^
```

### What's worth discussing about this pull request?

Is this a big enough use case to warrant the extra work? I think so.

### What downsides are there to merging this pull request?

A slightly more complex parser.