### PR TITLE
Switch from -- to - in command-line arguments

### DIFF
--- a/Sources/file-check/main.swift
+++ b/Sources/file-check/main.swift
@@ -11,18 +11,18 @@ func run() -> Int {
   let binder = ArgumentBinder<FileCheckOptions>()
   //swiftlint:disable statement_position
   binder.bind(option:
-    cli.add(option: "--disable-colors", kind: Bool.self,
+    cli.add(option: "-disable-colors", kind: Bool.self,
             usage: "Disable colorized diagnostics"),
               to: { if $1 { $0.insert(.disableColors) }
                     else { $0.remove(.disableColors) } })
   binder.bind(option:
-    cli.add(option: "--use-strict-whitespace",
+    cli.add(option: "-use-strict-whitespace",
             kind: Bool.self,
             usage: "Do not treat all horizontal whitespace as equivalent"),
               to: { if $1 { $0.insert(.strictWhitespace) }
                     else { $0.remove(.strictWhitespace) } })
   binder.bind(option:
-    cli.add(option: "--allow-empty-input", shortName: "-e",
+    cli.add(option: "-allow-empty-input", shortName: "-e",
             kind: Bool.self,
             usage: """
                    Allow the input file to be empty. This is useful when \
@@ -32,24 +32,24 @@ func run() -> Int {
               to: { if $1 { $0.insert(.allowEmptyInput) }
                     else { $0.remove(.allowEmptyInput) } })
   binder.bind(option:
-    cli.add(option: "--match-full-lines",
+    cli.add(option: "-match-full-lines",
             kind: Bool.self,
             usage: """
                    Require all positive matches to cover an entire input line. \
                    Allows leading and trailing whitespace if \
-                   --strict-whitespace is not also used.
+                   -strict-whitespace is not also used.
                    """),
               to: { if $1 { $0.insert(.matchFullLines) }
                     else { $0.remove(.matchFullLines) } })
   let prefixes =
-    cli.add(option: "--prefixes", kind: [String].self,
+    cli.add(option: "-prefixes", kind: [String].self,
             usage: """
                    Specifies one or more prefixes to match. By default these \
                    patterns are prefixed with “CHECK”.
                    """)
 
   let inputFile =
-    cli.add(option: "--input-file", shortName: "-i",
+    cli.add(option: "-input-file", shortName: "-i",
             kind: String.self,
             usage: "The file to use for checked input. Defaults to stdin.")
 

--- a/Sources/lite/main.swift
+++ b/Sources/lite/main.swift
@@ -20,7 +20,7 @@ import Glibc
 let cli = ArgumentParser(commandName: "lite", usage: "", overview: "")
 
 let testDir =
-  cli.add(option: "--test-dir", shortName: "-d",
+  cli.add(option: "-test-dir", shortName: "-d",
           kind: String.self,
           usage: """
                  The top-level directory containing tests to run. \
@@ -28,7 +28,7 @@ let testDir =
                  """)
 
 let siltExe =
-  cli.add(option: "--silt", kind: String.self,
+  cli.add(option: "-silt", kind: String.self,
           usage: """
                  The path to the `silt` executable. \
                  Defaults to the executable next to `lite`.

--- a/Sources/silt/main.swift
+++ b/Sources/silt/main.swift
@@ -53,21 +53,21 @@ func parseOptions() -> Options {
 
   binder.bind(
     option: cli.add(
-      option: "--dump",
+      option: "-dump",
       kind: Mode.DumpLayer.self,
       usage: "Dump the result of compiling up to a given layer"),
     to: { opt, r in opt.mode = .dump(r) })
   binder.bind(
     option: cli.add(
-      option: "--verify",
+      option: "-verify",
       kind: Mode.VerifyLayer.self,
       usage: "Verify the result of compiling up to a given layer"),
     to: { opt, r in opt.mode = .verify(r) })
   binder.bind(
-    option: cli.add(option: "--no-colors", kind: Bool.self),
+    option: cli.add(option: "-no-colors", kind: Bool.self),
     to: { opt, r in opt.colorsEnabled = !r })
   binder.bind(
-    option: cli.add(option: "--debug-print-timing", kind: Bool.self),
+    option: cli.add(option: "-debug-print-timing", kind: Bool.self),
     to: { opt, r in opt.shouldPrintTiming = r })
   binder.bindArray(
     positional: cli.add(

--- a/Tests/Parse/ambiguous-parens.silt
+++ b/Tests/Parse/ambiguous-parens.silt
@@ -1,4 +1,4 @@
--- RUN: %silt --verify parse %s
+-- RUN: %silt -verify parse %s
 module ambiguous-parens where
 
 -- #49: Used to have trouble parsing this because we couldn't tell the

--- a/Tests/Parse/basics.silt
+++ b/Tests/Parse/basics.silt
@@ -1,5 +1,5 @@
--- RUN: %silt %s --dump parse --no-colors 2>&1 | %FileCheck %s --prefixes CHECK-AST
--- RUN: %silt %s --dump shined 2>&1 | %FileCheck %s --prefixes CHECK-SHINED
+-- RUN: %silt %s -dump parse -no-colors 2>&1 | %FileCheck %s -prefixes CHECK-AST
+-- RUN: %silt %s -dump shined 2>&1 | %FileCheck %s -prefixes CHECK-SHINED
 
 -- CHECK-AST: moduleDecl
 -- CHECK-AST: identifier "Basics"

--- a/Tests/Parse/datatypes.silt
+++ b/Tests/Parse/datatypes.silt
@@ -1,5 +1,5 @@
--- RUN: %silt %s --dump parse --no-colors 2>&1 | %FileCheck %s --prefixes CHECK-AST
--- RUN: %silt %s --dump shined 2>&1 | %FileCheck %s --prefixes CHECK-SHINED
+-- RUN: %silt %s -dump parse -no-colors 2>&1 | %FileCheck %s -prefixes CHECK-AST
+-- RUN: %silt %s -dump shined 2>&1 | %FileCheck %s -prefixes CHECK-SHINED
 
 -- CHECK-AST: moduleDecl
 -- CHECK-AST:   identifier "DataTypes"

--- a/Tests/Parse/invalid-data-decl.silt
+++ b/Tests/Parse/invalid-data-decl.silt
@@ -1,4 +1,4 @@
--- RUN: %silt --verify parse %s
+-- RUN: %silt -verify parse %s
 module DataDecl where
 
 data Foo : Set where

--- a/Tests/Parse/invalid-parameters.silt
+++ b/Tests/Parse/invalid-parameters.silt
@@ -1,4 +1,4 @@
--- RUN: %silt --verify parse %s
+-- RUN: %silt -verify parse %s
 
 module InvalidParameters where
 

--- a/Tests/Parse/no-module.silt
+++ b/Tests/Parse/no-module.silt
@@ -1,4 +1,4 @@
--- RUN: %silt --verify parse %s
+-- RUN: %silt -verify parse %s
 id : ∀ {A: Type} A -> A
 -- expected-error@-1 {{missing required top level module}}
 id x = x

--- a/Tests/ScopeCheck/bad-scope.silt
+++ b/Tests/ScopeCheck/bad-scope.silt
@@ -1,4 +1,4 @@
--- RUN: %silt --verify scopes %s
+-- RUN: %silt -verify scopes %s
 
 module bad-scope where
 


### PR DESCRIPTION
### What's in this pull request?

This patch just switches the `--`'s from long command line options to `-` to match LLVM style.

### Why merge this pull request?

Consistency, really.

### What's worth discussing about this pull request?

Should we do this?

### What downsides are there to merging this pull request?

Different from some other tools, but more consistent with LLVM-style programs.
