### PR TITLE
Use Lite's new parallel execution mode

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
       dependencies: ["Utility"]),
     .target(
       name: "lite",
-      dependencies: ["Symbolic", "LiteSupport", "silt"]),
+      dependencies: ["Symbolic", "LiteSupport", "silt", "Utility"]),
     .target(
       name: "file-check",
       dependencies: ["Drill", "FileCheck", "Utility"]),

--- a/Sources/lite/main.swift
+++ b/Sources/lite/main.swift
@@ -36,7 +36,7 @@ let siltExe =
 
 let runSerial =
   cli.add(option: "--no-parallel", kind: Bool.self,
-          usage: "Don't run tests in parallel order.")
+          usage: "Don't run tests in order.")
 
 func run() -> Int32 {
   let args = Array(CommandLine.arguments.dropFirst())

--- a/Sources/lite/main.swift
+++ b/Sources/lite/main.swift
@@ -34,6 +34,10 @@ let siltExe =
                  Defaults to the executable next to `lite`.
                  """)
 
+let runSerial =
+  cli.add(option: "--no-parallel", kind: Bool.self,
+          usage: "Don't run tests in parallel order.")
+
 func run() -> Int32 {
   let args = Array(CommandLine.arguments.dropFirst())
   guard let result = try? cli.parse(args) else {
@@ -58,11 +62,15 @@ func run() -> Int32 {
     substitutions.append(("FileCheck", "\"\(filecheckURL.path)\""))
   }
 
+  let isParallel = !(result.get(runSerial) ?? false)
+  let parallelismLevel: ParallelismLevel = isParallel ? .automatic : .none
+
   do {
     let allPassed = try runLite(substitutions: substitutions,
                                 pathExtensions: ["silt"],
                                 testDirPath: result.get(testDir),
-                                testLinePrefix: "--")
+                                testLinePrefix: "--",
+                                parallelismLevel: parallelismLevel)
     return allPassed ? EXIT_SUCCESS : EXIT_FAILURE
   } catch let err as LiteError {
     engine.diagnose(.init(.error, err.message))

--- a/Sources/lite/main.swift
+++ b/Sources/lite/main.swift
@@ -36,7 +36,7 @@ let siltExe =
 
 let runSerial =
   cli.add(option: "--no-parallel", kind: Bool.self,
-          usage: "Don't run tests in order.")
+          usage: "Don't run tests in parallel.")
 
 func run() -> Int32 {
   let args = Array(CommandLine.arguments.dropFirst())


### PR DESCRIPTION
### What's in this pull request?

This change makes the `lite` target use `Lite`'s parallel execution mode (with a flag `--no-parallel` to disable it).

### Why merge this pull request?

As we add more tests, this will become much more important. This cuts the time to run the Trill test suite by 75%.

It currently runs our test suite in half the time, though that's not really that important because it runs in less than a second anyway.

Serial:
![ezgif-3-6bfccd744a](https://user-images.githubusercontent.com/853032/33808168-cd255df2-ddaf-11e7-8447-bfbff1550503.gif)

Parallel:
![ezgif-3-e0788af25e](https://user-images.githubusercontent.com/853032/33808172-d0846a60-ddaf-11e7-8c15-66ee80f87430.gif)

### What's worth discussing about this pull request?

Should we default to parallel or serial?

### What downsides are there to merging this pull request?

There is a bit more overhead per test, but it doesn't scale with the execution time of the tests, and it's ~150ms.