### PR TITLE
Work around ScopeCheck's Jank

### DIFF
--- a/Sources/Moho/Reparse.swift
+++ b/Sources/Moho/Reparse.swift
@@ -133,8 +133,10 @@ public struct NewNotation: CustomStringConvertible {
 extension NameBinding {
   /// Walks the module and registers any encountered user-defined notations in
   /// a scope.
-  func walkNotations(_ module: ModuleDeclSyntax) -> Scope {
+  func walkNotations(
+    _ module: ModuleDeclSyntax, _ name: FullyQualifiedName) -> Scope {
     return self.underScope { (scope) -> Scope in
+      scope.nameSpace = NameSpace(name)
       for d in module.declList {
         switch d {
         case let node as FunctionDeclSyntax:

--- a/Tests/ScopeCheck/bad-scope.silt
+++ b/Tests/ScopeCheck/bad-scope.silt
@@ -14,7 +14,7 @@ typo x = x
 typo2 : forall {A : Type} -> A -> B -- expected-error {{use of undeclared identifier 'B'}}
 typo2 x = x
 
-apply-missing-var : forall {A B : Type}{x : A}{f : A -> Type} -> f x -> f y -- expected-error {{use of undeclared identifier 'y'}}
+apply-missing-var : forall {A B : Type}{x : A}{f : A -> Type} -> (f x) -> (f y) -- expected-error {{use of undeclared identifier 'y'}}
 apply-missing-var x = x
 
 body-before-sig x = x -- expected-error {{function body for 'body-before-sig' must appear after function type signature}}
@@ -41,7 +41,7 @@ data N : Type where
 
 data Vec (X : Type) : N -> Type where
   | [] : Vec X zero
-  | cons : {n : N} -> X -> Vec X n -> Vec X (succ n)
+  | cons : {n : N} -> X -> (Vec X n) -> (Vec X (succ n))
 
-bad-head : forall {n : N}{X : Type} -> Vec X (suc n) -> X -- expected-error {{use of undeclared identifier 'suc'}}
+bad-head : forall {n : N}{X : Type} -> (Vec X (suc n)) -> X -- expected-error {{use of undeclared identifier 'suc'}}
 bad-head (cons x xs) = x


### PR DESCRIPTION
Fix support for rebinding arrows by breaking it a little.  Temporary workaround for applications in-between arrows by making them explicit.