### PR TITLE
Parser recovery for declarations

### DIFF
--- a/Tests/Parse/invalid-data-decl.silt
+++ b/Tests/Parse/invalid-data-decl.silt
@@ -1,12 +1,13 @@
 -- RUN: %silt --verify parse %s
 module DataDecl where
 
-data Foo : Set where
+data Foo : Type where
   | Foo : nat -> nat -> Foo
   | Bar : nat -> Foo
 
-data Bar : Set where
--- FIXME: This error is awful.
--- expected-error @1 {{expected declaration}}
-| Bar : nat -> nat -> Bar
-| Baz : nat -> Bar
+data Bar : Type where
+| Bar : nat -> nat -> Bar -- expected-error {{data constructors may only appear within the scope of a data declaration}}
+| Baz : nat -> Bar -- expected-error {{data constructors may only appear within the scope of a data declaration}}
+
+data UnePipe : Type where
+  ceciNestPas : UnePipe -- expected-error {{type constructors must be preceded by '|'}}


### PR DESCRIPTION
Recover from some common cases

- Missing pipes in data constructor declarations

```agda
data Foo where
  bar : Foo
```

- Constructors in the wrong scope

```agda
data Foo where
| bar : Foo
```

- Qualified names in telescopes

```agda
foo : {A.name : Type} -> A
```
