### PR TITLE
Add EmptyDataDeclSyntax and remove '|'

### DIFF
--- a/Sources/Crust/Parser.swift
+++ b/Sources/Crust/Parser.swift
@@ -538,8 +538,7 @@ extension Parser {
     let dataId = try parseIdentifierToken()
     let paramList = try parseTypedParameterList()
     let indices = try parseTypeIndices()
-    if peek() == .whereKeyword {
-      let whereTok = try consume(.whereKeyword)
+    if let whereTok = try consumeIf(.whereKeyword) {
       let leftBrace = try consume(.leftBrace)
       let constrList = try parseConstructorList()
       let rightBrace = try consume(.rightBrace)

--- a/Sources/Lithosphere/SyntaxKind.swift
+++ b/Sources/Lithosphere/SyntaxKind.swift
@@ -16,6 +16,7 @@ public enum SyntaxKind {
   case openImportDecl
   case importDecl
   case dataDecl
+  case emptyDataDecl
   case typeIndices
   case typedParameterList
   case ascription
@@ -96,6 +97,8 @@ extension Syntax {
       return ImportDeclSyntax(root: root, data: data)
     case .dataDecl:
       return DataDeclSyntax(root: root, data: data)
+    case .emptyDataDecl:
+      return EmptyDataDeclSyntax(root: root, data: data)
     case .typeIndices:
       return TypeIndicesSyntax(root: root, data: data)
     case .typedParameterList:

--- a/Sources/Lithosphere/SyntaxNodes.swift
+++ b/Sources/Lithosphere/SyntaxNodes.swift
@@ -313,6 +313,68 @@ public class DataDeclSyntax: DeclSyntax {
 
 }
 
+public class EmptyDataDeclSyntax: DeclSyntax {
+  public enum Cursor: Int {
+    case dataToken
+    case dataIdentifier
+    case typedParameterList
+    case typeIndices
+    case trailingSemicolon
+  }
+
+  public convenience init(dataToken: TokenSyntax, dataIdentifier: TokenSyntax, typedParameterList: TypedParameterListSyntax, typeIndices: TypeIndicesSyntax, trailingSemicolon: TokenSyntax) {
+    let raw = RawSyntax.node(.emptyDataDecl, [
+      dataToken.raw,
+      dataIdentifier.raw,
+      typedParameterList.raw,
+      typeIndices.raw,
+      trailingSemicolon.raw,
+    ], .present)
+    let data = SyntaxData(raw: raw, indexInParent: 0, parent: nil)
+    self.init(root: data, data: data)
+  }
+  public var dataToken: TokenSyntax {
+    return child(at: Cursor.dataToken) as! TokenSyntax
+  }
+  public func withDataToken(_ syntax: TokenSyntax) -> EmptyDataDeclSyntax {
+    let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.dataToken)
+    return EmptyDataDeclSyntax(root: newRoot, data: newData)
+  }
+
+  public var dataIdentifier: TokenSyntax {
+    return child(at: Cursor.dataIdentifier) as! TokenSyntax
+  }
+  public func withDataIdentifier(_ syntax: TokenSyntax) -> EmptyDataDeclSyntax {
+    let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.dataIdentifier)
+    return EmptyDataDeclSyntax(root: newRoot, data: newData)
+  }
+
+  public var typedParameterList: TypedParameterListSyntax {
+    return child(at: Cursor.typedParameterList) as! TypedParameterListSyntax
+  }
+  public func withTypedParameterList(_ syntax: TypedParameterListSyntax) -> EmptyDataDeclSyntax {
+    let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.typedParameterList)
+    return EmptyDataDeclSyntax(root: newRoot, data: newData)
+  }
+
+  public var typeIndices: TypeIndicesSyntax {
+    return child(at: Cursor.typeIndices) as! TypeIndicesSyntax
+  }
+  public func withTypeIndices(_ syntax: TypeIndicesSyntax) -> EmptyDataDeclSyntax {
+    let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.typeIndices)
+    return EmptyDataDeclSyntax(root: newRoot, data: newData)
+  }
+
+  public var trailingSemicolon: TokenSyntax {
+    return child(at: Cursor.trailingSemicolon) as! TokenSyntax
+  }
+  public func withTrailingSemicolon(_ syntax: TokenSyntax) -> EmptyDataDeclSyntax {
+    let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.trailingSemicolon)
+    return EmptyDataDeclSyntax(root: newRoot, data: newData)
+  }
+
+}
+
 public class TypeIndicesSyntax: Syntax {
   public enum Cursor: Int {
     case colonToken
@@ -487,28 +549,18 @@ public typealias ConstructorListSyntax = SyntaxCollection<ConstructorDeclSyntax>
 
 public class ConstructorDeclSyntax: DeclSyntax {
   public enum Cursor: Int {
-    case pipeToken
     case ascription
     case trailingSemicolon
   }
 
-  public convenience init(pipeToken: TokenSyntax, ascription: AscriptionSyntax, trailingSemicolon: TokenSyntax) {
+  public convenience init(ascription: AscriptionSyntax, trailingSemicolon: TokenSyntax) {
     let raw = RawSyntax.node(.constructorDecl, [
-      pipeToken.raw,
       ascription.raw,
       trailingSemicolon.raw,
     ], .present)
     let data = SyntaxData(raw: raw, indexInParent: 0, parent: nil)
     self.init(root: data, data: data)
   }
-  public var pipeToken: TokenSyntax {
-    return child(at: Cursor.pipeToken) as! TokenSyntax
-  }
-  public func withPipeToken(_ syntax: TokenSyntax) -> ConstructorDeclSyntax {
-    let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.pipeToken)
-    return ConstructorDeclSyntax(root: newRoot, data: newData)
-  }
-
   public var ascription: AscriptionSyntax {
     return child(at: Cursor.ascription) as! AscriptionSyntax
   }

--- a/Sources/SyntaxGen/SyntaxNodes.swift
+++ b/Sources/SyntaxGen/SyntaxNodes.swift
@@ -56,7 +56,7 @@ let syntaxNodes = [
 
   // MARK: Data types
 
-  // data-decl ::= 'data' <id> <typed-parameter-list>? <type-indices>? 'where' '{' <constructor-list> '}' ';'
+  // data-decl ::= 'data' <id> <typed-parameter-list>? <type-indices>? 'where'? '{' <constructor-list> '}' ';'
 
   Node("DataDecl", kind: "Decl", children: [
     Child("dataToken", kind: "DataToken"),
@@ -67,6 +67,14 @@ let syntaxNodes = [
     Child("leftBraceToken", kind: "LeftBraceToken"),
     Child("constructorList", kind: "ConstructorList"),
     Child("rightBraceToken", kind: "RightBraceToken"),
+    Child("trailingSemicolon", kind: "SemicolonToken"),
+  ]),
+
+  Node("EmptyDataDecl", kind: "Decl", children: [
+    Child("dataToken", kind: "DataToken"),
+    Child("dataIdentifier", kind: "IdentifierToken"),
+    Child("typedParameterList", kind: "TypedParameterList"),
+    Child("typeIndices", kind: "TypeIndices"),
     Child("trailingSemicolon", kind: "SemicolonToken"),
   ]),
 
@@ -116,7 +124,6 @@ let syntaxNodes = [
   // constructor-decl ::= '|' <ascription>
 
   Node("ConstructorDecl", kind: "Decl", children: [
-    Child("pipeToken", kind: "PipeToken"),
     Child("ascription", kind: "Ascription"),
     Child("trailingSemicolon", kind: "SemicolonToken"),
   ]),

--- a/Syntax/silt-layout.bnf
+++ b/Syntax/silt-layout.bnf
@@ -21,7 +21,7 @@ typed-parameter ::= '(' <ascription> ')'
                   | '{' <ascription> '}'
 constructor-list ::= <constructor-decl>
                    | <constructor-decl> <constructor-decl-list>
-constructor-decl ::= '|' <ascription> ';'
+constructor-decl ::= <ascription> ';'
 
 ## Records
 

--- a/Syntax/silt-layout.bnf
+++ b/Syntax/silt-layout.bnf
@@ -4,6 +4,7 @@ id-list ::= <id> | <id-list>
 # Declarations
 
 decl ::= <data-decl>
+       | <empty-data-decl>
        | <record-decl>
        | <module-decl>
        | <import-decl>
@@ -12,7 +13,8 @@ decl ::= <data-decl>
 
 ## Data types
 
-data-decl ::= 'data' <id> <typed-parameter-list>? <type-indices>? 'where' '{ ' <constructor-list> '}' ';'
+empty-data-decl ::= 'data' <id> <typed-parameter-list> <type-indices>
+data-decl ::= 'data' <id> <typed-parameter-list> <type-indices> 'where' '{ ' <constructor-list> '}' ';'
 type-indices ::= ':' <expr>
 typed-parameter-list ::= <typed-parameter>
                       | <typed-parameter> <typed-parameter-list>

--- a/Syntax/silt.bnf
+++ b/Syntax/silt.bnf
@@ -6,6 +6,7 @@ int ::= [0-9]+
 # Declarations
 
 decl ::= <data-decl>
+      || <empty-data-decl>
        | <record-decl>
        | <module-decl>
        | <import-decl>
@@ -15,7 +16,8 @@ decl ::= <data-decl>
 
 ## Data types
 
-data-decl ::= 'data' <id> <typed-parameter-list>? <type-indices>? 'where'? <constructor-list>
+empty-data-decl ::= 'data' <id> <typed-parameter-list> <type-indices>
+data-decl ::= 'data' <id> <typed-parameter-list> <type-indices> 'where' <constructor-list>
 type-indices ::= ':' <expr>
 typed-parameter-list ::= <typed-parameter>
                       | <typed-parameter> <typed-parameter-list>

--- a/Syntax/silt.bnf
+++ b/Syntax/silt.bnf
@@ -15,7 +15,7 @@ decl ::= <data-decl>
 
 ## Data types
 
-data-decl ::= 'data' <id> <typed-parameter-list>? <type-indices>? 'where' <constructor-list>
+data-decl ::= 'data' <id> <typed-parameter-list>? <type-indices>? 'where'? <constructor-list>
 type-indices ::= ':' <expr>
 typed-parameter-list ::= <typed-parameter>
                       | <typed-parameter> <typed-parameter-list>
@@ -24,7 +24,7 @@ typed-parameter ::= '(' <ascription> ')'
                   | '{' <ascription> '}'
 constructor-list ::= <constructor-decl>
                    | <constructor-decl> <constructor-decl-list>
-constructor-decl ::= '|' <ascription>
+constructor-decl ::= <ascription>
 
 ## Records
 

--- a/Tests/Parse/datatypes.silt
+++ b/Tests/Parse/datatypes.silt
@@ -21,16 +21,14 @@ data N : Type where
 -- CHECK-AST: constructorList
 
 -- CHECK-AST: constructorDecl
--- CHECK-AST:   pipe
 -- CHECK-AST:   ascription
 -- CHECK-AST      identifier "zero"
 -- CHECK-AST:     colon
 -- CHECK-AST      identifier "N"
--- CHECK-SHINED: | zero : N;
-  | zero : N
+-- CHECK-SHINED: zero : N;
+  zero : N
 
 -- CHECK-AST: constructorDecl
--- CHECK-AST:   pipe
 -- CHECK-AST:   ascription
 -- CHECK-AST      identifier "succ"
 -- CHECK-AST:     colon
@@ -39,8 +37,8 @@ data N : Type where
 -- CHECK-AST          identifier "N"
 -- CHECK-AST          arrow
 -- CHECK-AST          identifier "N"
--- CHECK-SHINED: | succ : N -> N;
-  | succ : N -> N
+-- CHECK-SHINED: succ : N -> N;
+  succ : N -> N
 
 -- CHECK-SHINED: };
 

--- a/Tests/Parse/invalid-data-decl.silt
+++ b/Tests/Parse/invalid-data-decl.silt
@@ -2,12 +2,10 @@
 module DataDecl where
 
 data Foo : Type where
-  | Foo : nat -> nat -> Foo
-  | Bar : nat -> Foo
+  Foo : nat -> nat -> Foo
+  Bar : nat -> Foo
 
-data Bar : Type where
-| Bar : nat -> nat -> Bar -- expected-error {{data constructors may only appear within the scope of a data declaration}}
-| Baz : nat -> Bar -- expected-error {{data constructors may only appear within the scope of a data declaration}}
-
-data UnePipe : Type where
-  ceciNestPas : UnePipe -- expected-error {{type constructors must be preceded by '|'}}
+data Bar : Type where -- expected-error {{data declaration with no constructors cannot have a 'where' clause}}
+-- expected-note @-1 {{remove 'where' to make an empty data declaration}}
+Bar : nat -> nat -> Bar -- expected-error {{data constructors may only appear within the scope of a data declaration}}
+-- expected-note @-1 {{indent this declaration to make it a constructor}}

--- a/Tests/ScopeCheck/ambiguous-operators.silt
+++ b/Tests/ScopeCheck/ambiguous-operators.silt
@@ -3,13 +3,13 @@
 module ambiguous-operators where
 
 data True : Type where
-  | tt : True
+  tt : True
 
-data False : Type where
+data False : Type
 
 data Bool : Type where
-  | false : Bool
-  | true  : Bool
+  false : Bool
+  true  : Bool
 
 if_then_else_ : Bool -> {A : Type} -> A -> A -> A
 if true  then x else y = x

--- a/Tests/ScopeCheck/bad-scope.silt
+++ b/Tests/ScopeCheck/bad-scope.silt
@@ -32,16 +32,16 @@ bad-lambdas = \ x -> (\ y -> (a w))
 --expected-error @-2 {{use of undeclared identifier 'w'}}
 
 data BadNat : Typo where -- expected-error {{use of undeclared identifier 'Typo'}}
-  | z : BadNat
-  | s : BadNat -> BadNot -- expected-error {{use of undeclared identifier 'BadNot'}}
+  z : BadNat
+  s : BadNat -> BadNot -- expected-error {{use of undeclared identifier 'BadNot'}}
 
 data N : Type where
-  | zero : N
-  | succ : N -> N
+  zero : N
+  succ : N -> N
 
 data Vec (X : Type) : N -> Type where
-  | [] : Vec X zero
-  | cons : {n : N} -> X -> Vec X n -> Vec X (succ n)
+  [] : Vec X zero
+  cons : {n : N} -> X -> Vec X n -> Vec X (succ n)
 
 bad-head : forall {n : N}{X : Type} -> Vec X (suc n) -> X -- expected-error {{use of undeclared identifier 'suc'}}
 bad-head (cons x xs) = x

--- a/Tests/ScopeCheck/operators.silt
+++ b/Tests/ScopeCheck/operators.silt
@@ -3,13 +3,13 @@
 module operators where
 
 data True : Type where
-  | tt : True
+  tt : True
 
-data False : Type where
+data False : Type
 
 data Bool : Type where
-  | false : Bool
-  | true  : Bool
+  false : Bool
+  true  : Bool
 
 -- An operator is declared with '_' where the arguments go
 if_then_else_ : Bool -> {A : Type} -> A -> A -> A

--- a/Tests/TypeCheck/bad-types.silt
+++ b/Tests/TypeCheck/bad-types.silt
@@ -13,16 +13,16 @@ flip : forall {A B : Type} {C : A -> B -> Type} ->
 flip f = \ y x -> f x y
 
 data List (A : Type) : Type where
-  | Nil  : List A
-  | Cons : A -> List A -> List A
+  Nil  : List A
+  Cons : A -> List A -> List A
 
 append : forall {A : Type} -> List A -> List A -> List A
 append Nil ys = ys
 append (Cons x xs) ys = Cons x (append xs ys)
 
 data N : Type where
-  | Z : N
-  | S : N -> N
+  Z : N
+  S : N -> N
 
 seven : N
 seven = S (S (S (S (S (S (S Z))))))


### PR DESCRIPTION
This brings the syntax more in line with Agda, and splitting empty data
decls gives us more flexibility when doing parser recovery to detect bad
constructors.

The strategy here: If you have a data declaration with a `where`, you
best have a constructor next to it. If not, that's an error. If there's
a function directly after one such data declaration, suggest indenting
it to make it a constructor.