### PR TITLE
Require type indices on record declarations

### DIFF
--- a/Sources/Crust/Shine.swift
+++ b/Sources/Crust/Shine.swift
@@ -216,7 +216,8 @@ public func layout(_ ts: [TokenSyntax]) -> [TokenSyntax] {
                                          presence: .implicit))
         continue
       } else {
-        while let (_, block) = layoutBlockStack.last, !block.lessThanOrEqual(wsp) {
+        while
+          let (_, block) = layoutBlockStack.last, !block.lessThanOrEqual(wsp) {
           _ = layoutBlockStack.popLast()
           if !layoutBlockStack.isEmpty {
             stainlessToks.append(TokenSyntax(.rightBrace,
@@ -228,7 +229,8 @@ public func layout(_ ts: [TokenSyntax]) -> [TokenSyntax] {
 
         if layoutBlockStack.isEmpty {
           layoutBlockStack.append((.whereKeyword, wsp))
-        } else if let (_, block) = layoutBlockStack.last, !wsp.equivalentTo(block) {
+        } else if
+          let (_, block) = layoutBlockStack.last, !wsp.equivalentTo(block) {
           // If we must, begin a new layout block
           layoutBlockStack.append((.whereKeyword, wsp))
         }
@@ -256,7 +258,8 @@ public func layout(_ ts: [TokenSyntax]) -> [TokenSyntax] {
         stainlessToks.append(TokenSyntax(.semicolon, presence: .implicit))
       } else if ws.lessThan(lastBlock) {
         stainlessToks.append(TokenSyntax(.semicolon, presence: .implicit))
-        while let (_, block) = layoutBlockStack.last, !block.lessThanOrEqual(ws) {
+        while
+          let (_, block) = layoutBlockStack.last, !block.lessThanOrEqual(ws) {
           _ = layoutBlockStack.popLast()
           if !layoutBlockStack.isEmpty {
             stainlessToks.append(TokenSyntax(.rightBrace,

--- a/Sources/Lithosphere/SyntaxNodes.swift
+++ b/Sources/Lithosphere/SyntaxNodes.swift
@@ -592,12 +592,12 @@ public class RecordDeclSyntax: DeclSyntax {
     case trailingSemicolon
   }
 
-  public convenience init(recordToken: TokenSyntax, recordName: TokenSyntax, parameterList: TypedParameterListSyntax, typeIndices: TypeIndicesSyntax?, whereToken: TokenSyntax, leftParenToken: TokenSyntax, recordElementList: DeclListSyntax, rightParenToken: TokenSyntax, trailingSemicolon: TokenSyntax) {
+  public convenience init(recordToken: TokenSyntax, recordName: TokenSyntax, parameterList: TypedParameterListSyntax, typeIndices: TypeIndicesSyntax, whereToken: TokenSyntax, leftParenToken: TokenSyntax, recordElementList: DeclListSyntax, rightParenToken: TokenSyntax, trailingSemicolon: TokenSyntax) {
     let raw = RawSyntax.node(.recordDecl, [
       recordToken.raw,
       recordName.raw,
       parameterList.raw,
-      typeIndices?.raw ?? RawSyntax.missing(.typeIndices),
+      typeIndices.raw,
       whereToken.raw,
       leftParenToken.raw,
       recordElementList.raw,
@@ -631,8 +631,8 @@ public class RecordDeclSyntax: DeclSyntax {
     return RecordDeclSyntax(root: newRoot, data: newData)
   }
 
-  public var typeIndices: TypeIndicesSyntax? {
-    return child(at: Cursor.typeIndices) as? TypeIndicesSyntax
+  public var typeIndices: TypeIndicesSyntax {
+    return child(at: Cursor.typeIndices) as! TypeIndicesSyntax
   }
   public func withTypeIndices(_ syntax: TypeIndicesSyntax) -> RecordDeclSyntax {
     let (newRoot, newData) = data.replacingChild(syntax.raw, at: Cursor.typeIndices)

--- a/Sources/Moho/ScopeCheck.swift
+++ b/Sources/Moho/ScopeCheck.swift
@@ -459,9 +459,8 @@ extension NameBinding {
       (TypeSignature, Name, [DeclaredField], [Name], [Decl], [ArgumentPlicity])
     let checkedData = self.underScope {_ -> ScopeCheckType? in
       let params = syntax.parameterList.map(self.scopeCheckParameter)
-      let capType = syntax.typeIndices.map({
-        return self.scopeCheckExpr(self.reparseExpr($0.indexExpr))
-      }) ?? Expr.type
+      let indices = self.reparseExpr(syntax.typeIndices.indexExpr)
+      let checkedIndices = self.scopeCheckExpr(indices)
 
       var preSigs = [DeclaredField]()
       var decls = [Decl]()
@@ -491,7 +490,7 @@ extension NameBinding {
         return nil
       }
 
-      let (ty, names, plicity) = self.rollPi(params, capType)
+      let (ty, names, plicity) = self.rollPi(params, checkedIndices)
       let recordSignature = TypeSignature(name: boundDataName,
                                           type: ty, plicity: plicity)
       return (recordSignature, recConstr, preSigs, names, decls, plicity)

--- a/Sources/SyntaxGen/SyntaxNodes.swift
+++ b/Sources/SyntaxGen/SyntaxNodes.swift
@@ -136,7 +136,7 @@ let syntaxNodes = [
     Child("recordToken", kind: "RecordToken"),
     Child("recordName", kind: "IdentifierToken"),
     Child("parameterList", kind: "TypedParameterList"),
-    Child("typeIndices", kind: "TypeIndices", isOptional: true),
+    Child("typeIndices", kind: "TypeIndices"),
     Child("whereToken", kind: "WhereToken"),
     Child("leftParenToken", kind: "LeftParenToken"),
     Child("recordElementList", kind: "DeclList"),

--- a/Tests/Parse/invalid-data-decl.silt
+++ b/Tests/Parse/invalid-data-decl.silt
@@ -13,3 +13,7 @@ Bar : nat -> nat -> Bar -- expected-error {{data constructors may only appear wi
 data NoIndices where -- expected-error {{declaration of 'NoIndices' is missing type ascription}}
 -- expected-note @-1 {{add a type ascription; e.g. ': Type'}}
   x : NoIndices
+
+record MissingIndices where -- expected-error {{declaration of 'MissingIndices' is missing type ascription}}
+-- expected-note@-1 {{add a type ascription; e.g. ': Type'}}
+

--- a/Tests/ScopeCheck/records.silt
+++ b/Tests/ScopeCheck/records.silt
@@ -10,14 +10,14 @@ data String : Type where
   [] : String
   _,_ : Nat -> String -> String
 
-record MissingPerson where -- expected-error {{record 'records.MissingPerson' must have constructor declared}}
+record MissingPerson : Type where -- expected-error {{record 'records.MissingPerson' must have constructor declared}}
   firstName, middleName, lastName : String
   age : Nat
 
 missing-fred : MissingPerson
 missing-fred = MkMissingPerson [] [] [] Z -- expected-error {{use of undeclared identifier 'MkMissingPerson'}}
 
-record Person where
+record Person : Type where
   constructor MkPerson
   field
     firstName, middleName, lastName : String

--- a/Tests/TypeCheck/records.silt
+++ b/Tests/TypeCheck/records.silt
@@ -10,7 +10,7 @@ data String : Type where
   [] : String
   _,,_ : Nat -> String -> String
 
-record Person where
+record Person : Type where
   constructor MkPerson
   field
     firstName, middleName, lastName : String


### PR DESCRIPTION
The empty record declaration is inhabited by the empty record
constructor

```silt
record True : Type where

tt : True
tt = record {}
```