### PR TITLE
Type Checking for local declarations bindings

### DIFF
--- a/Sources/Mantle/Check.swift
+++ b/Sources/Mantle/Check.swift
@@ -46,7 +46,7 @@ extension TypeChecker where PhaseState == CheckPhaseState {
     return Module(telescope: paramCtx, inside: Set(names))
   }
 
-  private func checkDecl(_ d: Decl) -> Opened<QualifiedName, TT> {
+  public func checkDecl(_ d: Decl) -> Opened<QualifiedName, TT> {
     return self.underExtendedEnvironment([]) {
       switch d {
       case let .dataSignature(sig):
@@ -65,10 +65,45 @@ extension TypeChecker where PhaseState == CheckPhaseState {
         return self.checkRecord(name, paramNames, conName, fieldSigs)
       case let .module(mod):
         return self.checkModuleCommon(mod)
+      case let .letBinding(name, clause):
+        return self.checkLetBinding(name, clause)
       default:
         fatalError()
       }
     }
+  }
+
+  private func checkLetBinding(_ name: QualifiedName,
+    _ clause: DeclaredClause) -> Opened<QualifiedName, TT> {
+
+    guard let bodyExpr = clause.body.expr else {
+      fatalError("let binding with no body?")
+    }
+
+    let bindingLambda =
+      clause.patterns.reversed().reduce(bodyExpr) { expr, pat in
+        guard let name = pat.name else {
+          fatalError("let bindings can not have constructors")
+        }
+        return Expr.lambda((name, .meta), expr)
+      }
+
+    let ctxLambda = self.environment.asContext.reversed().reduce(bindingLambda, { expr, entry in
+      return Expr.lambda((entry.0, .meta), expr)
+    })
+
+    let clauseMetaVar = self.signature.addMeta(.type, from: bodyExpr)
+    let clauseMeta = TT.apply(.meta(clauseMetaVar), [])
+    _ = self.checkExpr(ctxLambda, clauseMeta)
+    let elimClauseTy = self.eliminate(clauseMeta,
+                                      self.environment.forEachVariable { v in
+      return Elim<TT>.apply(TT.apply(.variable(v), []))
+    })
+    self.signature.addLetBinding(name, type: elimClauseTy,
+                                 self.environment.asContext)
+    return self.openDefinition(name, environment.forEachVariable { variable in
+      return TT.apply(.variable(variable), [])
+    })
   }
 
   private func checkModuleCommon(
@@ -334,8 +369,7 @@ extension TypeChecker where PhaseState == CheckPhaseState {
       case (.type, .type, .type):
         return
       case let (.pi(dom, cod), .lambda(body1), .lambda(body2)):
-        let name = TokenSyntax(.identifier("_")) // FIXME: Try harder, maybe
-        let ctx2 = [(Name(name: name), dom)] + ctx
+        let ctx2 = [(wildcardName, dom)] + ctx
         return self.checkDefinitionallyEqual(ctx2, cod, body1, body2)
       case let (_, .apply(h1, elims1), .apply(h2, elims2)):
         guard h1 == h2 else {
@@ -346,7 +380,6 @@ extension TypeChecker where PhaseState == CheckPhaseState {
                                      TT.apply(h1, []), elims1, elims2)
       default:
         print(typeView, t1View, t2View)
-        fatalError("Terms not equal")
       }
     }
   }
@@ -404,8 +437,7 @@ extension TypeChecker where PhaseState == CheckPhaseState {
         self.extendEnvironment([(name, patType)])
         return (.variable, type)
       case .wild:
-        let name = TokenSyntax(.identifier("_")) // FIXME: Try harder, maybe
-        self.extendEnvironment([(Name(name: name), patType)])
+        self.extendEnvironment([(wildcardName, patType)])
         return (.variable, type)
       case let .constructor(dataCon, synPats):
         // Use the data constructor to locate back up the parent so we can
@@ -570,10 +602,9 @@ extension TypeChecker where PhaseState == CheckPhaseState {
       guard case let .pi(domain, codomain) = type else {
         fatalError()
       }
-      let name = TokenSyntax(.identifier("_")) // FIXME: Try harder, maybe
       return self.checkTT(body,
                           hasType: codomain,
-                          in: [(Name(name: name), domain)] + ctx)
+                          in: [(wildcardName, domain)] + ctx)
     default:
       let infType = self.infer(term, in: ctx)
       return self.checkDefinitionallyEqual(ctx, TT.type, infType, type)

--- a/Sources/Mantle/Infer.swift
+++ b/Sources/Mantle/Infer.swift
@@ -63,7 +63,8 @@ extension TypeChecker where PhaseState == CheckPhaseState {
         case .constant(_, .data(_)),
              .constant(_, .record(_, _)),
              .constant(_, .postulate),
-             .projection(_, _, _):
+             .projection(_, _, _),
+             .letBinding(_, _):
           guard seenHeads.insert(.definition(name.key)).inserted else {
             return .notInvertible(cs)
           }

--- a/Sources/Mantle/Infer.swift
+++ b/Sources/Mantle/Infer.swift
@@ -19,8 +19,7 @@ extension TypeChecker where PhaseState == CheckPhaseState {
       return .type
     case let .pi(domain, codomain):
       self.checkTT(domain, hasType: TT.type, in: ctx)
-      let name = TokenSyntax(.identifier("_")) // FIXME: Try harder, maybe
-      self.checkTT(codomain, hasType: TT.type, in: [(Name(name: name), domain)])
+      self.checkTT(codomain, hasType: TT.type, in: [(wildcardName, domain)])
       return TT.type
     case let .apply(head, elims):
       var type = self.infer(head, in: ctx)

--- a/Sources/Mantle/Invert.swift
+++ b/Sources/Mantle/Invert.swift
@@ -55,8 +55,7 @@ extension TypeChecker {
     }
     let zips = zip((0..<vars.count).reversed(), vars)
     let subs = zips.map({ (idx, v) -> (Var, Term<TT>) in
-      let name = TokenSyntax(.identifier("_")) // FIXME: Try harder, maybe
-      return (v, TT.apply(.variable(Var(Name(name: name), UInt(idx))), []))
+      return (v, TT.apply(.variable(Var(wildcardName, UInt(idx))), []))
     })
     return Inversion(substitution: subs, arity: subs.count)
   }

--- a/Sources/Mantle/Normalize.swift
+++ b/Sources/Mantle/Normalize.swift
@@ -145,8 +145,7 @@ extension TypeChecker {
         return term
       }
     case .pi(_, _):
-      let name = TokenSyntax(.identifier("_")) // FIXME: Try harder, maybe
-      let v = TT.apply(Head.variable(Var(Name(name: name), 0)), [])
+      let v = TT.apply(Head.variable(Var(wildcardName, 0)), [])
       switch self.toWeakHeadNormalForm(term).ignoreBlocking {
       case .lambda(_):
         return term

--- a/Sources/Mantle/Prune.swift
+++ b/Sources/Mantle/Prune.swift
@@ -63,14 +63,12 @@ extension TypeChecker {
     case .refl:
       return .refl
     case let .lambda(body):
-      let name = TokenSyntax(.identifier("_")) // FIXME: Try harder, maybe
-      let weakBody = self.pruneTerm(weakenSet(vs, Var(Name(name: name), 0)),
+      let weakBody = self.pruneTerm(weakenSet(vs, Var(wildcardName, 0)),
                                     body)
       return TT.lambda(weakBody)
     case let .pi(domain, codomain):
-      let name = TokenSyntax(.identifier("_")) // FIXME: Try harder, maybe
       return TT.pi(self.pruneTerm(vs, domain),
-                   self.pruneTerm(weakenSet(vs, Var(Name(name: name), 0)),
+                   self.pruneTerm(weakenSet(vs, Var(wildcardName, 0)),
                                   codomain))
     case let .equal(type, x, y):
       return TT.equal(self.pruneTerm(vs, type),

--- a/Sources/Mantle/Signature.swift
+++ b/Sources/Mantle/Signature.swift
@@ -137,6 +137,14 @@ extension Signature {
                                             inside: newDef))
   }
 
+  func addLetBinding(_ name: QualifiedName, type: Type<TT>,
+                     _ tel: Telescope<TT>) {
+    let definition = Definition.constant(type, .function(.open))
+    self.addDefinition(name,
+                       ContextualDefinition(telescope: tel,
+                                            inside: definition))
+  }
+
   func addFunctionClauses(
     _ name: Opened<QualifiedName, TT>, _ inv: Instantiability.Invertibility) {
     let def = self.lookupDefinition(name.key)!

--- a/Sources/Mantle/Signature.swift
+++ b/Sources/Mantle/Signature.swift
@@ -137,9 +137,10 @@ extension Signature {
                                             inside: newDef))
   }
 
-  func addLetBinding(_ name: QualifiedName, type: Type<TT>,
-                     _ tel: Telescope<TT>) {
-    let definition = Definition.constant(type, .function(.open))
+  func addLetBinding(
+    _ name: QualifiedName, type: Type<TT>, tel: Telescope<TT>) {
+    let ctxTy = ContextualType(telescope: tel, inside: type)
+    let definition = Definition.letBinding(name, ctxTy)
     self.addDefinition(name,
                        ContextualDefinition(telescope: tel,
                                             inside: definition))

--- a/Sources/Mantle/Solve.swift
+++ b/Sources/Mantle/Solve.swift
@@ -104,7 +104,7 @@ indirect enum SolverConstraint: CustomDebugStringConvertible {
   var debugDescription: String {
     switch self {
     case let .unify(_, ty, tm1, tm2):
-      return "\(tm1): \(ty) == \(tm2): \(ty)"
+      return "\(tm1) : \(ty) == \(tm2): \(ty)"
     case let .suppose(con1, con2):
       return "(\(con1.debugDescription)) => (\(con2.debugDescription))"
     case let .conjoin(cs):
@@ -113,7 +113,7 @@ indirect enum SolverConstraint: CustomDebugStringConvertible {
       let desc = zip(elims1, elims2).map({ (e1, e2) in
         return "\(e1) == \(e2)"
       }).joined(separator: " , ")
-      return "(\(mbH?.description ?? "??")[\(desc)]: \(ty))"
+      return "(\(mbH?.description ?? "??")[\(desc)] : \(ty))"
     }
   }
 
@@ -341,8 +341,7 @@ extension TypeChecker where PhaseState == SolvePhaseState {
                               constrArgs1.map(Elim<TT>.apply),
                               constrArgs2.map(Elim<TT>.apply))
     case let (.pi(dom, cod), .lambda(body1), .lambda(body2)):
-      let name = TokenSyntax(.identifier("_")) // FIXME: Try harder, maybe
-      let ctx2 = ctx + [(Name(name: name), dom)]
+      let ctx2 = ctx + [(wildcardName, dom)]
       return self.unify((ctx2, cod, body1, body2))
     case let (_, .apply(head1, elims1), .apply(head2, elims2)):
       guard head1 == head2 else {
@@ -354,8 +353,7 @@ extension TypeChecker where PhaseState == SolvePhaseState {
       return self.equalSpines(ctx, headTy, headTm, elims1, elims2)
     case let (.type, .pi(dom1, cod1), .pi(dom2, cod2)):
       let piType = { () -> Type<TT> in
-        let name = TokenSyntax(.identifier("A")) // FIXME: Try harder, maybe
-        let avar = TT.apply(.variable(Var(Name(name: name), 0)), [])
+        let avar = TT.apply(.variable(Var(wildcardName, 0)), [])
         return TT.pi(.type, .pi(.pi(avar, .type), .type))
       }()
       let cod1p = TT.lambda(cod1)

--- a/Sources/Mantle/Substitution.swift
+++ b/Sources/Mantle/Substitution.swift
@@ -400,6 +400,8 @@ extension Definition: Substitutable {
                             inside: mod.inside))
     case let .projection(proj, tyName, ctxTy):
       return .projection(proj, tyName, try ctxTy.applySubstitution(subst, elim))
+    case let .letBinding(name, ctxTy):
+      return .letBinding(name, try ctxTy.applySubstitution(subst, elim))
     }
   }
 }
@@ -435,6 +437,8 @@ extension OpenedDefinition: Substitutable {
                             inside: mod.inside))
     case let .projection(proj, tyName, ctxTy):
       return .projection(proj, tyName, try ctxTy.applySubstitution(subst, elim))
+    case let .letBinding(name, ctxTy):
+      return .letBinding(name, try ctxTy.applySubstitution(subst, elim))
     }
   }
 }

--- a/Sources/Mantle/Support.swift
+++ b/Sources/Mantle/Support.swift
@@ -130,7 +130,7 @@ public enum Definition {
   case constant(Type<TT>, Constant)
   case dataConstructor(QualifiedName, UInt, ContextualType)
   case projection(Projection.Field, QualifiedName, ContextualType)
-
+  case letBinding(QualifiedName, ContextualType)
   case module(Module)
 }
 
@@ -152,6 +152,7 @@ public enum OpenedDefinition {
   case dataConstructor(Opened<QualifiedName, TT>, UInt, ContextualType)
   case module(Module)
   case projection(Projection.Field, Opened<QualifiedName, TT>, ContextualType)
+  case letBinding(Opened<QualifiedName, TT>, ContextualType)
 }
 
 // MARK: Expressions
@@ -376,8 +377,8 @@ public final class Environment {
     let ctx = self.asContext
     var result = [T]()
     result.reserveCapacity(ctx.count)
-    for (ix, (n, _)) in ctx.enumerated() {
-      result.append(f(Var(n, UInt(ix))))
+    for (ix, (n, _)) in zip((0..<ctx.count).reversed(), ctx).reversed() {
+      result.insert(f(Var(n, UInt(ix))), at: 0)
     }
     return result
   }

--- a/Sources/Mantle/TypeChecker.swift
+++ b/Sources/Mantle/TypeChecker.swift
@@ -54,6 +54,16 @@ public final class TypeChecker<PhaseState> {
   public var environment: Environment {
     return self.state.environment
   }
+
+  /// FIXME: Try harder, maybe
+  public var wildcardToken: TokenSyntax {
+    return TokenSyntax.implicit(.underscore)
+  }
+
+  /// FIXME: Try harder, maybe
+  public var wildcardName: Name {
+    return Name(name: wildcardToken)
+  }
 }
 
 extension TypeChecker {
@@ -127,6 +137,25 @@ extension TypeChecker {
       tel.append((name, dm))
     }
     return (tel, ty)
+  }
+
+  // Takes a Pi-type and replaces all it's elements with metavariables.
+  func fillPiWithMetas(_ ty: Type<TT>) -> [Term<TT>] {
+    var type = self.toWeakHeadNormalForm(ty).ignoreBlocking
+    var metas = [Term<TT>]()
+    while true {
+      switch type {
+      case let .pi(domain, codomain):
+        let meta = self.addMeta(in: self.environment.asContext, expect: domain)
+        let instCodomain = self.forceInstantiate(codomain, [meta])
+        type = self.toWeakHeadNormalForm(instCodomain).ignoreBlocking
+        metas.append(meta)
+      case .type:
+        return metas
+      default:
+        fatalError("Expected Pi")
+      }
+    }
   }
 }
 

--- a/Tests/TypeCheck/let-binding.silt
+++ b/Tests/TypeCheck/let-binding.silt
@@ -1,4 +1,4 @@
--- RUN-XFAIL: %silt --dump typecheck %s
+-- RUN: %silt --dump typecheck %s
 
 module LetBinding where
 

--- a/Tests/TypeCheck/let-binding.silt
+++ b/Tests/TypeCheck/let-binding.silt
@@ -1,0 +1,14 @@
+-- RUN-XFAIL: %silt --dump typecheck %s
+
+module LetBinding where
+
+infix 20 _$_
+
+_$_ : {A : Type} -> {B : Type} -> (A -> B) -> A -> B
+f $ x = f x
+
+testSimpleLetBinding : {A : Type} -> A -> A
+testSimpleLetBinding x = let y = x in y
+
+testComplexLetBinding : {A : Type} -> {B : Type} -> (A -> B) -> A -> B
+testComplexLetBinding f x = let g y = let z = y in f z in g x


### PR DESCRIPTION
Builds on #78.  Type checking like this spawns an ungodly number of metavariables.