### PR TITLE
Fix off-by-ordering of the context and re-work let bindings

### DIFF
--- a/Sources/Mantle/Infer.swift
+++ b/Sources/Mantle/Infer.swift
@@ -63,8 +63,7 @@ extension TypeChecker where PhaseState == CheckPhaseState {
         case .constant(_, .data(_)),
              .constant(_, .record(_, _)),
              .constant(_, .postulate),
-             .projection(_, _, _),
-             .letBinding(_, _):
+             .projection(_, _, _):
           guard seenHeads.insert(.definition(name.key)).inserted else {
             return .notInvertible(cs)
           }

--- a/Sources/Mantle/Prune.swift
+++ b/Sources/Mantle/Prune.swift
@@ -118,13 +118,6 @@ extension TypeChecker {
       }
       return prunes.reduce(false, { $0 || $1})
     case let .apply(.definition(f), _):
-      // HACK: Let bindings are ill-constraint and leaking into the outer
-      // environment and affecting downstream metas.  This stops Pruning from
-      // crashing but the better fix is to properly implement local bindings.
-      let def = self.signature.lookupDefinition(f.key)!
-      if case .letBinding(_, _) = def.inside {
-        return nil
-      }
       guard self.isNeutral(f) else {
         return nil
       }

--- a/Sources/Mantle/Signature.swift
+++ b/Sources/Mantle/Signature.swift
@@ -137,15 +137,6 @@ extension Signature {
                                             inside: newDef))
   }
 
-  func addLetBinding(
-    _ name: QualifiedName, type: Type<TT>, tel: Telescope<TT>) {
-    let ctxTy = ContextualType(telescope: tel, inside: type)
-    let definition = Definition.letBinding(name, ctxTy)
-    self.addDefinition(name,
-                       ContextualDefinition(telescope: tel,
-                                            inside: definition))
-  }
-
   func addFunctionClauses(
     _ name: Opened<QualifiedName, TT>, _ inv: Instantiability.Invertibility) {
     let def = self.lookupDefinition(name.key)!

--- a/Sources/Mantle/Substitution.swift
+++ b/Sources/Mantle/Substitution.swift
@@ -400,8 +400,6 @@ extension Definition: Substitutable {
                             inside: mod.inside))
     case let .projection(proj, tyName, ctxTy):
       return .projection(proj, tyName, try ctxTy.applySubstitution(subst, elim))
-    case let .letBinding(name, ctxTy):
-      return .letBinding(name, try ctxTy.applySubstitution(subst, elim))
     }
   }
 }
@@ -437,8 +435,6 @@ extension OpenedDefinition: Substitutable {
                             inside: mod.inside))
     case let .projection(proj, tyName, ctxTy):
       return .projection(proj, tyName, try ctxTy.applySubstitution(subst, elim))
-    case let .letBinding(name, ctxTy):
-      return .letBinding(name, try ctxTy.applySubstitution(subst, elim))
     }
   }
 }

--- a/Sources/Mantle/Support.swift
+++ b/Sources/Mantle/Support.swift
@@ -134,7 +134,6 @@ public enum Definition {
   case constant(Type<TT>, Constant)
   case dataConstructor(QualifiedName, UInt, ContextualType)
   case projection(Projection.Field, QualifiedName, ContextualType)
-  case letBinding(QualifiedName, ContextualType)
   case module(Module)
 }
 
@@ -156,7 +155,6 @@ public enum OpenedDefinition {
   case dataConstructor(Opened<QualifiedName, TT>, UInt, ContextualType)
   case module(Module)
   case projection(Projection.Field, Opened<QualifiedName, TT>, ContextualType)
-  case letBinding(Opened<QualifiedName, TT>, ContextualType)
 }
 
 // MARK: Expressions
@@ -369,10 +367,10 @@ public final class Environment {
     return self.asContext.isEmpty
   }
 
-  /// Retrieves the environment as one contiguous context with the current
-  /// context at the fore and subsequent blocks in LIFO order in back.
+  /// Retrieves the environment as one contiguous context with ancestor
+  /// blocks in FIFO order and the current context at the rear.
   public var asContext: Context {
-    return self.context + self.scopes.reversed().flatMap({ $0.context })
+    return self.scopes.flatMap({ $0.context }) + self.context
   }
 
   /// Returns an array containing the result of mapping the given function

--- a/Sources/Mantle/TypeChecker.swift
+++ b/Sources/Mantle/TypeChecker.swift
@@ -206,8 +206,6 @@ extension TypeChecker {
       return .module(names)
     case let .projection(proj, tyName, ctxType):
       return .projection(proj, Opened<QualifiedName, TT>(tyName, args), ctxType)
-    case let .letBinding(name, ctxType):
-      return .letBinding(Opened<QualifiedName, TT>(name, args), ctxType)
     }
   }
 
@@ -254,17 +252,6 @@ extension TypeChecker {
       return self.rollPi(in: ct.telescope, final: ct.inside)
     case let .projection(_, _, ct):
       return self.rollPi(in: ct.telescope, final: ct.inside)
-    case let .letBinding(_, ct):
-      var ty = ct.inside
-      for _ in ct.telescope {
-        guard
-          case let .pi(_, cd) = self.toWeakHeadNormalForm(ty).ignoreBlocking
-        else {
-          fatalError("Type doesn't contain enough Pi's?")
-        }
-        ty = cd
-      }
-      return ty
     case .module(_):
       fatalError()
     }


### PR DESCRIPTION
This is the solution I wanted to work the first time around.  The
context was completely ass-backwards and we weren’t ever running into
problems because of this because nothing up to this point had ever
opened a local scope for type checking.

Reverts all the horrid nonsense I had put in to work around this.  Typechecking where clauses is now trivial.