### PR TITLE
Add `unreachable` PrimOp

### DIFF
--- a/Sources/OuterCore/IRBuilder.swift
+++ b/Sources/OuterCore/IRBuilder.swift
@@ -70,4 +70,8 @@ extension IRBuilder {
   ) -> SwitchConstrOp {
     return insert(SwitchConstrOp(parent, matching: src, patterns: caseVals))
   }
+
+  public func createUnreachable() -> UnreachableOp {
+    return insert(UnreachableOp())
+  }
 }

--- a/Sources/OuterCore/IRWriter.swift
+++ b/Sources/OuterCore/IRWriter.swift
@@ -328,4 +328,8 @@ extension GIRWriter: PrimOpVisitor {
   public func visitDataInitSimpleOp(_ op: DataInitSimpleOp) {
     self.write(op.constructor)
   }
+
+  public func visitUnreachableOp(_ op: UnreachableOp) {
+    self.write("unreachable")
+  }
 }

--- a/Sources/OuterCore/PrimOp.swift
+++ b/Sources/OuterCore/PrimOp.swift
@@ -34,7 +34,12 @@ public class PrimOp: Value {
     /// An operation that represents a reference to a continuation.
     case functionRef = "function_ref"
 
+    /// A simple constructor call with no parameters
     case dataInitSimple = "data_init_simple"
+
+    /// An instruction that is considered 'unreachable' that will trap at
+    /// runtime.
+    case unreachable
   }
 
   /// All the operands of this operation.
@@ -216,6 +221,12 @@ public final class DataInitSimpleOp: PrimOp {
   }
 }
 
+public final class UnreachableOp: PrimOp {
+  public init() {
+    super.init(opcode: .unreachable)
+  }
+}
+
 public protocol PrimOpVisitor {
   func visitApplyOp(_ op: ApplyOp)
   func visitCopyValueOp(_ op: CopyValueOp)
@@ -223,6 +234,7 @@ public protocol PrimOpVisitor {
   func visitFunctionRefOp(_ op: FunctionRefOp)
   func visitSwitchConstrOp(_ op: SwitchConstrOp)
   func visitDataInitSimpleOp(_ op: DataInitSimpleOp)
+  func visitUnreachableOp(_ op: UnreachableOp)
 }
 
 extension PrimOpVisitor {
@@ -242,6 +254,8 @@ extension PrimOpVisitor {
     case .switchConstr: self.visitSwitchConstrOp(code as! SwitchConstrOp)
       // swiftlint:disable force_cast
     case .dataInitSimple: self.visitDataInitSimpleOp(code as! DataInitSimpleOp)
+    // swiftlint:disable force_cast
+    case .unreachable: self.visitUnreachableOp(code as! UnreachableOp)
     }
   }
 }

--- a/Sources/Seismography/ParseGIR.swift
+++ b/Sources/Seismography/ParseGIR.swift
@@ -321,6 +321,8 @@ extension GIRParser {
       let typeRepr = try self.parser.parseGIRTypeExpr()
 
       resultValue = B.createDataInitSimple(ident.render)
+    case .unreachable:
+      resultValue = B.createUnreachable()
     }
 
     guard let resName = resultName, let resValue = resultValue else {


### PR DESCRIPTION
### What's in this pull request?

This patch adds an `unreachable` PrimOp, and adds writing and parsing for it.

### Why merge this pull request?

It's necessary to have as a placeholder while debugging codegen. It also trivially lowers to LLVM's unreachable instruction.

### What's worth discussing about this pull request?

Nothing. Resolves #101.

### What downsides are there to merging this pull request?

None.
