### PR TITLE
Cleanup before GIRGen

### DIFF
--- a/Sources/Mantle/Check.swift
+++ b/Sources/Mantle/Check.swift
@@ -46,7 +46,7 @@ extension TypeChecker where PhaseState == CheckPhaseState {
     let names = self.underExtendedEnvironment(paramCtx) {
       return syntax.decls.map { self.checkDecl($0).key }
     }
-    return Module(telescope: paramCtx, inside: Set(names))
+    return Module(telescope: paramCtx, inside: names)
   }
 
   public func checkDecl(_ d: Decl) -> Opened<QualifiedName, TT> {

--- a/Sources/Mantle/Normalize.swift
+++ b/Sources/Mantle/Normalize.swift
@@ -153,7 +153,7 @@ extension TypeChecker {
         return nil
       case let .apply(.definition(_), es):
         return self.elimsAsPatterns(es)
-      case let .apply(.variable(v), es) where es.isEmpty:
+      case let .apply(.variable(_), es) where es.isEmpty:
         fatalError(expr.description)
       default:
         fatalError(expr.description)

--- a/Sources/Mantle/Signature.swift
+++ b/Sources/Mantle/Signature.swift
@@ -190,15 +190,15 @@ extension Signature {
 }
 
 extension Signature {
-  func lookupMetaBinding(_ mv: Meta) -> Meta.Binding? {
+  public func lookupMetaBinding(_ mv: Meta) -> Meta.Binding? {
     return self.metaBindings[mv]
   }
 
-  func lookupMetaType(_ mv: Meta) -> TT? {
+  public func lookupMetaType(_ mv: Meta) -> TT? {
     return self.metaTypes[mv]
   }
 
-  func lookupDefinition(_ name: QualifiedName) -> ContextualDefinition? {
+  public func lookupDefinition(_ name: QualifiedName) -> ContextualDefinition? {
     return self.definitions[name]
   }
 }

--- a/Sources/Mantle/Support.swift
+++ b/Sources/Mantle/Support.swift
@@ -108,11 +108,19 @@ extension Opened where K: Equatable, T: Equatable {
 /// Every term may be lifted to a contextual term - in the trivial case one has
 /// an empty telescope.
 public struct Contextual<T, A> {
-  let telescope: Telescope<T>
-  let inside: A
+  public let telescope: Telescope<T>
+  public let inside: A
 }
 
-public typealias Module = Contextual<TT, Set<QualifiedName>>
+public struct TopLevelModule {
+  public let name: QualifiedName
+  public let signature: Signature
+  public let environment: Environment
+  public let rootModule: Module
+  public let tc: TypeChecker<CheckPhaseState>
+}
+
+public typealias Module = Contextual<TT, [QualifiedName]>
 public typealias ContextualDefinition = Contextual<TT, Definition>
 public typealias ContextualType = Contextual<TT, Type<TT>>
 
@@ -390,7 +398,7 @@ public final class Environment {
   ///
   /// The returned variable contains the appropriate de Bruijn index for the
   /// associated term.
-  func lookupName(_ name: Name, _ elim: (TT, [Elim<TT>]) -> TT) -> (Var, TT)? {
+  public func lookupName(_ name: Name, _ elim: (TT, [Elim<TT>]) -> TT) -> (Var, TT)? {
     guard !self.isEmpty else {
       return nil
     }
@@ -408,7 +416,7 @@ public final class Environment {
 
   /// Looks up a de Bruijn-indexed variable in the current environment.  If no
   /// such entry exists, the result is `nil`.
-  func lookupVariable(_ v: Var, _ elim: (TT, [Elim<TT>]) -> TT) -> TT? {
+  public func lookupVariable(_ v: Var, _ elim: (TT, [Elim<TT>]) -> TT) -> TT? {
     let ctx = self.asContext
     if v.index > UInt(ctx.count) {
       return nil
@@ -528,8 +536,8 @@ public struct Projection: Equatable {
 // MARK: Clauses
 
 public struct Clause {
-  let patterns: [Pattern]
-  let body: Term<TT>?
+  public let patterns: [Pattern]
+  public let body: Term<TT>?
 
   var boundCount: Int {
     return self.patterns.reduce(0) { (acc, next) in
@@ -556,7 +564,7 @@ public enum Instantiability {
     case notInvertible([Clause])
     case invertible([Clause])
 
-    var ignoreInvertibility: [Clause] {
+    public var ignoreInvertibility: [Clause] {
       switch self {
       case let .notInvertible(cs): return cs
       case let .invertible(cs): return cs

--- a/Sources/Mantle/TypeChecker.swift
+++ b/Sources/Mantle/TypeChecker.swift
@@ -141,7 +141,7 @@ extension TypeChecker {
   }
 
   // Unroll a Pi type into a telescope of names and types and the final type.
-  func unrollPi(
+  public func unrollPi(
     _ t: Type<TT>, _ ns: [Name]? = nil) -> (Telescope<Type<TT>>, Type<TT>) {
     // FIXME: Try harder, maybe
     let defaultName = Name(name: TokenSyntax(.identifier("_")))

--- a/Sources/Moho/Syntax.swift
+++ b/Sources/Moho/Syntax.swift
@@ -139,29 +139,6 @@ public struct TypeSignature {
   public let plicity: [ArgumentPlicity]
 }
 
-/// Represents a fully scope-checked pattern.
-public enum Pattern {
-  /// A wildcard pattern.
-  ///
-  /// ```
-  /// foo _ _ _ = ...
-  /// ```
-  case wild
-  /// A variable pattern.
-  ///
-  /// ```
-  /// foo x y z = ...
-  /// ```
-  case variable(QualifiedName)
-  /// A constructor pattern.
-  ///
-  /// ```
-  /// foo [] x y          = ...
-  /// foo (cons x xs) y z = ...
-  /// ```
-  case constructor(QualifiedName, [Pattern])
-}
-
 /// Represents a clause in a pattern.
 public struct DeclaredClause: CustomStringConvertible {
   public let patterns: [DeclaredPattern]
@@ -196,9 +173,31 @@ public struct DeclaredClause: CustomStringConvertible {
 /// Represents an intermediate pattern that better conveys structure than the
 /// syntax tree.
 public enum DeclaredPattern: CustomStringConvertible {
+  /// A wildcard pattern.
+  ///
+  /// ```
+  /// foo _ _ _ = ...
+  /// ```
   case wild
+  /// A variable pattern.
+  ///
+  /// ```
+  /// foo x y z = ...
+  /// ```
   case variable(Name)
+  /// A constructor pattern.
+  ///
+  /// ```
+  /// foo [] x y          = ...
+  /// foo (_::_ x xs) y z = ...
+  /// ```
   case constructor(QualifiedName, [DeclaredPattern])
+  /// An uninhabited pattern.
+  ///
+  /// ```
+  /// foo [] ()          = ...
+  /// foo (_::_ x xs) () = ...
+  /// ```
   case absurd(AbsurdExprSyntax)
 
   public var name: Name? {

--- a/Sources/OuterCore/IRWriter.swift
+++ b/Sources/OuterCore/IRWriter.swift
@@ -83,7 +83,7 @@ func name(for value: Value) -> String {
     return "@\(escape(value.name))"
   case is Parameter:
     return "%\(escape(value.name))"
-  case is GIRType:
+  case is GIRExprType:
     return "TYPE"
   default:
     fatalError("attempt to serialize unknown value \(value)")

--- a/Sources/OuterCore/ParseGIR.swift
+++ b/Sources/OuterCore/ParseGIR.swift
@@ -182,7 +182,7 @@ extension GIRParser {
         _ = try self.parser.consume(.colon)
         let typeRepr = try self.parser.parseGIRTypeExpr()
 
-        let arg = cont.appendParameter(type: GIRType(typeRepr),
+        let arg = cont.appendParameter(type: GIRExprType(typeRepr),
                                        ownership: .owned)
 
         self.setLocalValue(arg, name)

--- a/Sources/Seismography/Continuation.swift
+++ b/Sources/Seismography/Continuation.swift
@@ -44,7 +44,7 @@ public final class Continuation: Value, Graph {
     }
   }
 
-  public override init(name: String, type: Type) {
+  public override init(name: String, type: GIRType) {
     self.predecessorList = Successor(nil)
     super.init(name: name, type: type)
   }

--- a/Sources/Seismography/DeclRef.swift
+++ b/Sources/Seismography/DeclRef.swift
@@ -1,0 +1,27 @@
+/// DeclRef.swift
+///
+/// Copyright 2017, The Silt Language Project.
+///
+/// This project is released under the MIT license, a copy of which is
+/// available in the repository.
+
+public struct DeclRef: Hashable {
+  public enum Kind: Int {
+    case function = 0
+  }
+  public let name: String
+  public let kind: Kind
+
+  public init(_ name: String, _ kind: Kind) {
+    self.name = name
+    self.kind = kind
+  }
+
+  public static func == (lhs: DeclRef, rhs: DeclRef) -> Bool {
+    return lhs.name == rhs.name && lhs.kind == rhs.kind
+  }
+
+  public var hashValue: Int {
+    return 0x9e3779b9 &* self.name.hashValue &+ self.kind.rawValue
+  }
+}

--- a/Sources/Seismography/GIRModule.swift
+++ b/Sources/Seismography/GIRModule.swift
@@ -33,21 +33,21 @@ public final class GIRModule {
   }
 
   public func recordType(name: String,
-                         indices: Type? = nil,
+                         indices: GIRType? = nil,
                          actions: (RecordType) -> Void) -> RecordType {
     let record = RecordType(name: name, indices: indices ?? TypeType.shared)
     actions(record)
     return knownRecordTypes.getOrInsert(record)
   }
 
-  public func functionType(arguments: [Type],
-                           returnType: Type) -> FunctionType {
+  public func functionType(arguments: [GIRType],
+                           returnType: GIRType) -> FunctionType {
     let function = FunctionType(arguments: arguments, returnType: returnType)
     return knownFunctionTypes.getOrInsert(function)
   }
 
   public func dataType(name: String,
-                       indices: Type? = nil,
+                       indices: GIRType? = nil,
                        actions: (DataType) -> Void) -> DataType {
     let data = DataType(name: name, indices: indices ?? TypeType.shared)
     actions(data)

--- a/Sources/Seismography/IRBuilder.swift
+++ b/Sources/Seismography/IRBuilder.swift
@@ -6,7 +6,6 @@
 /// available in the repository.
 
 import Foundation
-import Seismography
 
 public final class IRBuilder {
   public let module: GIRModule
@@ -16,7 +15,7 @@ public final class IRBuilder {
   }
 
   public func buildContinuation(
-    name: String, type: Type = BottomType.shared) -> Continuation {
+    name: String, type: GIRType = BottomType.shared) -> Continuation {
     let continuation = Continuation(name: name, type: type)
     module.addContinuation(continuation)
     return continuation


### PR DESCRIPTION
### What's in this pull request?

Narrowing the GIRGen patch to just the essentials.

- Changes internal references in the IRWriter to print `@bbN`-style instead of `@name` style for `function_ref` to better maintain the illusion of basic-blockiness.
- Remove `Pattern`.  Somehow I wrote `DeclaredPattern` and didn't notice...
- Rename `Type` to `GIRType` to not conflict with the Mantle.
- Rename `GIRType` to `GIRExprType` because we'll be deleting it anyways.
- Introduce a `DeclRef` structure.