### PR TITLE
Rename IRBuilder to GIRBuilder

### DIFF
--- a/Sources/Mesosphere/GIRGen.swift
+++ b/Sources/Mesosphere/GIRGen.swift
@@ -110,7 +110,7 @@ extension GIRGenModule {
 
 final class GIRGenFunction {
   var f: Continuation
-  let B: IRBuilder
+  let B: GIRBuilder
   let params: [(Name, Type<TT>)]
   let returnTy: Type<TT>
   let telescope: Telescope<TT>
@@ -120,7 +120,7 @@ final class GIRGenFunction {
   init(_ GGM: GIRGenModule, _ f: Continuation,
        _ ty: Type<TT>, _ tel: Telescope<TT>) {
     self.f = f
-    self.B = IRBuilder(module: GGM.M)
+    self.B = GIRBuilder(module: GGM.M)
     self.telescope = tel
     let (ps, result) = GGM.tc.unrollPi(ty)
     self.params = ps

--- a/Sources/OuterCore/GIRWriter.swift
+++ b/Sources/OuterCore/GIRWriter.swift
@@ -1,4 +1,4 @@
-/// IRWriter.swift
+/// GIRWriter.swift
 ///
 /// Copyright 2017, The Silt Language Project.
 ///

--- a/Sources/OuterCore/ParseGIR.swift
+++ b/Sources/OuterCore/ParseGIR.swift
@@ -50,7 +50,7 @@ public final class GIRParser {
     return try actions()
   }
 
-  func namedContinuation(_ B: IRBuilder, _ name: String) -> Continuation {
+  func namedContinuation(_ B: GIRBuilder, _ name: String) -> Continuation {
     // If there was no name specified for this block, just create a new one.
     if name.isEmpty {
       return B.buildContinuation(name: name)
@@ -73,7 +73,7 @@ public final class GIRParser {
   }
 
   func getReferencedContinuation(
-    _ B: IRBuilder, _ syntax: TokenSyntax) -> Continuation {
+    _ B: GIRBuilder, _ syntax: TokenSyntax) -> Continuation {
     assert(syntax.render.starts(with: "@"))
     let name = String(syntax.render.dropFirst())
     // If the block has already been created, use it.
@@ -131,7 +131,7 @@ extension GIRParser {
       _ = try self.parser.consume(.whereKeyword)
       let mod = GIRModule(name: moduleId)
       self.module = mod
-      let builder = IRBuilder(module: mod)
+      let builder = GIRBuilder(module: mod)
       try self.parseDecls(builder)
       assert(self.parser.currentToken?.tokenKind == .eof)
       return mod
@@ -140,13 +140,13 @@ extension GIRParser {
     }
   }
 
-  func parseDecls(_ B: IRBuilder) throws {
+  func parseDecls(_ B: GIRBuilder) throws {
     while self.parser.peek() != .rightBrace && self.parser.peek() != .eof {
       _ = try parseDecl(B)
     }
   }
 
-  func parseDecl(_ B: IRBuilder) throws -> Bool {
+  func parseDecl(_ B: GIRBuilder) throws -> Bool {
     guard
       case let .identifier(identStr) = parser.peek(), identStr.starts(with: "@")
     else {
@@ -167,7 +167,7 @@ extension GIRParser {
     }
   }
 
-  func parseGIRBasicBlock(_ B: IRBuilder) throws -> Bool {
+  func parseGIRBasicBlock(_ B: GIRBuilder) throws -> Bool {
     let ident = try self.parser.parseIdentifierToken()
     var blockName = ident.render
     if blockName.hasSuffix(":") {
@@ -212,7 +212,7 @@ extension GIRParser {
   }
 
   func parseGIRInstruction(
-    _ B: IRBuilder, in cont: Continuation) throws -> Bool {
+    _ B: GIRBuilder, in cont: Continuation) throws -> Bool {
     guard self.parser.peekToken()!.leadingTrivia.containsNewline else {
       fatalError("Instruction must begin on a new line")
     }

--- a/Sources/Seismography/GIRBuilder.swift
+++ b/Sources/Seismography/GIRBuilder.swift
@@ -1,4 +1,4 @@
-/// IRBuilder.swift
+/// GIRBuilder.swift
 ///
 /// Copyright 2017, The Silt Language Project.
 ///
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public final class IRBuilder {
+public final class GIRBuilder {
   public let module: GIRModule
 
   public init(module: GIRModule) {
@@ -26,7 +26,7 @@ public final class IRBuilder {
   }
 }
 
-extension IRBuilder {
+extension GIRBuilder {
   public func createApply(
     _ parent: Continuation, _ fnVal: Value, _ argVals: [Value]) -> ApplyOp {
     return insert(ApplyOp(parent, fnVal, argVals))


### PR DESCRIPTION
### What's in this pull request?

Rename `IRBuilder` to `GIRBuilder` so we don't have to qualify `LLVM.IRBuilder`.
It also renamed `IRWriter.swift` to `GIRWriter.swift`.

### Why merge this pull request?

We should avoid using `IR` in `GIR` classes, overall.

### What's worth discussing about this pull request?

I don't think anything.

### What downsides are there to merging this pull request?

None.

