### PR TITLE
Rename `--dump girGen` to `--dump girgen`

### DIFF
--- a/Sources/Drill/Options.swift
+++ b/Sources/Drill/Options.swift
@@ -42,6 +42,8 @@ public enum Mode {
     /// file from the token stream including implicit scope marking tokens.
     case shined
 
+    /// The compiler will lex, layout, parse, and scope check the source text
+    /// then print the scopes to stdout.
     case scopes
 
     /// The compiler will lex, layout, parse, scope check, then type check
@@ -50,8 +52,9 @@ public enum Mode {
 
     /// The compiler will lex, layout, parse, scope check, type check, then
     /// lower the module to GraphIR.
-    case girGen
+    case girGen = "girgen"
 
+    /// The compiler will parse a GIR module then dump the parsed module.
     case parseGIR = "parse-gir"
   }
   case dump(DumpLayer)

--- a/Tests/Mesosphere/dispatch-nested.silt
+++ b/Tests/Mesosphere/dispatch-nested.silt
@@ -1,4 +1,4 @@
--- RUN: %silt %s --dump girGen --no-colors 2>&1 | %FileCheck %s --prefixes CHECK-GIR
+-- RUN: %silt %s --dump girgen --no-colors 2>&1 | %FileCheck %s --prefixes CHECK-GIR
 
 -- CHECK-GIR: module dispatch-nested where
 module dispatch-nested where

--- a/Tests/Mesosphere/switch-dispatch.silt
+++ b/Tests/Mesosphere/switch-dispatch.silt
@@ -1,4 +1,4 @@
--- RUN: %silt %s --dump girGen --no-colors 2>&1 | %FileCheck %s
+-- RUN: %silt %s --dump girgen --no-colors 2>&1 | %FileCheck %s
 
 -- CHECK: module switch-dispatch where
 module switch-dispatch where

--- a/Tests/Mesosphere/unreachable.silt
+++ b/Tests/Mesosphere/unreachable.silt
@@ -1,4 +1,4 @@
--- RUN: %silt %s --dump girGen --no-colors 2>&1 | %FileCheck %s --prefixes CHECK-GIR
+-- RUN: %silt %s --dump girgen --no-colors 2>&1 | %FileCheck %s --prefixes CHECK-GIR
 
 
 -- CHECK-GIR: module unreachable where


### PR DESCRIPTION
### What's in this pull request?

This avoids mixing cases in command-line arguments. We don't want `kebab-case` mixed with `camelCase`.

Taking from `silgen`, I think `girgen` is one word, with no separator.

(This also adds a comment above two uncommented dump layers)

### Why merge this pull request?

Consistency.

### What's worth discussing about this pull request?

Should we split it into `gir-gen`?

### What downsides are there to merging this pull request?

¯\_(ツ)_/¯
