### PR TITLE
Add Hasher protocol and a stable hasher

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,8 +21,11 @@ let package = Package(
       name: "Crust",
       dependencies: ["Lithosphere"]),
     .target(
+      name: "Boring",
+      dependencies: []),
+    .target(
       name: "Drill",
-      dependencies: ["Lithosphere", "Crust", "Moho", "Mantle", "Mesosphere", "OuterCore", "Seismography", "Utility"]),
+      dependencies: ["Boring", "Lithosphere", "Crust", "Moho", "Mantle", "Mesosphere", "OuterCore", "Seismography", "Utility"]),
     .target(
       name: "silt",
       dependencies: ["Drill", "Utility"]),

--- a/Sources/Boring/Hasher.swift
+++ b/Sources/Boring/Hasher.swift
@@ -1,0 +1,135 @@
+/// Hasher.swift
+///
+/// Copyright 2018, The Silt Language Project.
+///
+/// This project is released under the MIT license, a copy of which is
+/// available in the repository.
+
+import Foundation
+
+public protocol Hasher {
+  associatedtype HashValueType
+
+  /// Initialize a new hasher from the default seed value.
+  /// The default seed is set during process startup, usually from a
+  /// high-quality random source.
+  init()
+  /// Initialize a new hasher from the specified seed value.
+  init(seed: (UInt64, UInt64))
+
+  /// Append the bit pattern `bits` to this hasher.
+  /// This adds exactly `Int.bitWidth` bits to the hasher state,
+  /// in native byte order.
+  mutating func append(bits: Int)
+
+  /// Append the bit pattern `bits` to this hasher.
+  /// This adds exactly `UInt.bitWidth` bits to the hasher state,
+  /// in native byte order.
+  mutating func append(bits: UInt)
+
+  /// Append the bit pattern `bits` to this hasher.
+  /// This adds exactly 8 bytes to the hasher state, in native byte order.
+  mutating func append(bits: Int64)
+
+  /// Append the bit pattern `bits` to this hasher.
+  /// This adds exactly 8 bytes to the hasher state, in native byte order.
+  mutating func append(bits: UInt64)
+
+  /// Append the bit pattern `bits` to this hasher.
+  /// This adds exactly 4 bytes to the hasher state, in native byte order.
+  mutating func append(bits: Int32)
+
+  /// Append the bit pattern `bits` to this hasher.
+  /// This adds exactly 4 bytes to the hasher state, in native byte order.
+  mutating func append(bits: UInt32)
+
+  /// Append the bit pattern `bits` to this hasher.
+  /// This adds exactly 2 bytes to the hasher state, in native byte order.
+  mutating func append(bits: Int16)
+
+  /// Append the bit pattern `bits` to this hasher.
+  /// This adds exactly 2 bytes to the hasher state, in native byte order.
+  mutating func append(bits: UInt16)
+
+  /// Append the single byte `bits` to this hasher.
+  mutating func append(bits: Int8)
+  /// Append the single byte `bits` to this hasher.
+  mutating func append(bits: UInt8)
+
+  /// Append the raw bytes in `buffer` to this hasher.
+  mutating func append(bits buffer: UnsafeRawBufferPointer)
+
+  /// Finalize the hasher state and return the hash value.
+  /// Finalizing invalidates the hasher; it cannot be appended to or
+  /// finalized again.
+  mutating func finalize() -> HashValueType
+}
+
+extension Hasher {
+  /// Append `value` to this hasher.
+  mutating func append<H: HashableByHasher>(_ value: H) {
+    value.hash(into: &self)
+  }
+}
+
+public protocol HashableByHasher: Hashable {
+  /// Hash the essential components of this value into the hash function
+  /// represented by `hasher`, by appending them to it.
+  ///
+  /// Essential components are precisely those that are compared in the type's
+  /// implementation of `Equatable`.
+  func hash<H: Hasher>(into hasher: inout H)
+}
+
+extension Int8: HashableByHasher {
+  public func hash<H: Hasher>(into hasher: inout H) {
+    hasher.append(bits: self)
+  }
+}
+extension Int16: HashableByHasher {
+  public func hash<H: Hasher>(into hasher: inout H) {
+    hasher.append(bits: self)
+  }
+}
+extension Int32: HashableByHasher {
+  public func hash<H: Hasher>(into hasher: inout H) {
+    hasher.append(bits: self)
+  }
+}
+extension Int64: HashableByHasher {
+  public func hash<H: Hasher>(into hasher: inout H) {
+    hasher.append(bits: self)
+  }
+}
+extension Int: HashableByHasher {
+  public func hash<H: Hasher>(into hasher: inout H) {
+    hasher.append(bits: self)
+  }
+}
+
+extension UInt8: HashableByHasher {
+  public func hash<H: Hasher>(into hasher: inout H) {
+    hasher.append(bits: self)
+  }
+}
+extension UInt16: HashableByHasher {
+  public func hash<H: Hasher>(into hasher: inout H) {
+    hasher.append(bits: self)
+  }
+}
+extension UInt32: HashableByHasher {
+  public func hash<H: Hasher>(into hasher: inout H) {
+    hasher.append(bits: self)
+  }
+}
+extension UInt64: HashableByHasher {
+  public func hash<H: Hasher>(into hasher: inout H) {
+    hasher.append(bits: self)
+  }
+}
+extension UInt: HashableByHasher {
+  public func hash<H: Hasher>(into hasher: inout H) {
+    hasher.append(bits: self)
+  }
+}
+

--- a/Sources/Boring/StableHasher.swift
+++ b/Sources/Boring/StableHasher.swift
@@ -1,0 +1,223 @@
+/// StableHasher.swift
+///
+/// Copyright 2018, The Silt Language Project.
+///
+/// This project is released under the MIT license, a copy of which is
+/// available in the repository.
+
+// An implementation of SipHash24
+///
+/// Partially from the Swift Standard Library, partially from the Rust
+/// Standard Library, partially from https://131002.net/siphash/.
+public struct SipHasher {
+  private enum Rounds {
+    internal static func sipRound(
+      v0: inout UInt64,
+      v1: inout UInt64,
+      v2: inout UInt64,
+      v3: inout UInt64
+    ) {
+      v0 = v0 &+ v1
+      v1 = rotateLeft(v1, by: 13)
+      v1 ^= v0
+      v0 = rotateLeft(v0, by: 32)
+      v2 = v2 &+ v3
+      v3 = rotateLeft(v3, by: 16)
+      v3 ^= v2
+      v0 = v0 &+ v3
+      v3 = rotateLeft(v3, by: 21)
+      v3 ^= v0
+      v2 = v2 &+ v1
+      v1 = rotateLeft(v1, by: 17)
+      v1 ^= v2
+      v2 = rotateLeft(v2, by: 32)
+    }
+  }
+
+  private struct State {
+    var v0: UInt64 = 0x736f6d6570736575
+    var v1: UInt64 = 0x646f72616e646f6d
+    var v2: UInt64 = 0x6c7967656e657261
+    var v3: UInt64 = 0x7465646279746573
+  }
+  private var state: State = State()
+
+  /// This value holds the byte count and the pending bytes that haven't been
+  /// compressed yet, in the format that the finalization step needs. (The least
+  /// significant 56 bits hold the trailing bytes, while the most significant 8
+  /// bits hold the count of bytes appended so far, mod 256.)
+  internal var tailAndByteCount: UInt64 = 0
+
+  public init() {
+    self.init(seed: (0, 0))
+  }
+
+  public init(seed: (UInt64, UInt64)) {
+    self.state.v3 ^= seed.1
+    self.state.v2 ^= seed.0
+    self.state.v1 ^= seed.1
+    self.state.v0 ^= seed.0
+  }
+
+  private var byteCount: UInt64 {
+    return tailAndByteCount &>> 56
+  }
+
+  private var tail: UInt64 {
+    return tailAndByteCount & ~(0xFF &<< 56)
+  }
+
+  private mutating func compress(_ value: UInt64) {
+    self.state.v3 ^= value
+    for _ in 0..<2 {
+      Rounds.sipRound(v0: &self.state.v0, v1: &self.state.v1,
+                       v2: &self.state.v2, v3: &self.state.v3)
+    }
+    self.state.v0 ^= value
+  }
+}
+
+extension SipHasher: Hasher {
+  public mutating func append(bits: UnsafeRawBufferPointer) {
+    assert(bits.count <= 8)
+
+    let length = UInt64(bits.count)
+
+    let needed = 8 - self.tail
+    let fill = min(length, needed)
+    let m: UInt64
+    if fill == 8 {
+      m = bits.load(as: UInt64.self)
+    } else {
+      m = extendHostToLittle(bits, start: 0, length: fill)
+    }
+    tailAndByteCount = (tailAndByteCount | m) &+ (8 &<< 56)
+    compress((m &<< 32) | tail)
+
+    let ntail = length - needed
+    let rest = extendHostToLittle(bits, start: Int(needed), length: ntail)
+    tailAndByteCount = ((ntail &+ 8) &<< 56) | (rest &>> 32)
+  }
+
+  public mutating func append(bits: Int8) {
+    var bitCpy = bits
+    withUnsafeBytes(of: &bitCpy) { ptr in
+      self.append(bits)
+    }
+  }
+
+  public mutating func append(bits: UInt8) {
+    var bitCpy = bits
+    withUnsafeBytes(of: &bitCpy) { ptr in
+      self.append(bits)
+    }
+  }
+
+  public mutating func append(bits: Int16) {
+    var bitCpy = bits
+    withUnsafeBytes(of: &bitCpy) { ptr in
+      self.append(bits)
+    }
+  }
+
+  public mutating func append(bits: UInt16) {
+    var bitCpy = bits
+    withUnsafeBytes(of: &bitCpy) { ptr in
+      self.append(bits)
+    }
+  }
+
+  public mutating func append(bits: Int) {
+    append(UInt(bitPattern: bits))
+  }
+
+  public mutating func append(bits: UInt) {
+    append(UInt64(_truncatingBits: bits._lowWord))
+  }
+
+  public mutating func append(bits: Int32) {
+    append(UInt32(bitPattern: bits))
+  }
+
+  public mutating func append(bits: UInt32) {
+    let m = UInt64(_truncatingBits: bits._lowWord)
+    if byteCount & 4 == 0 {
+      assert(byteCount & 7 == 0 && tail == 0)
+      tailAndByteCount = (tailAndByteCount | m) &+ (4 &<< 56)
+    } else {
+      assert(byteCount & 3 == 0)
+      compress((m &<< 32) | tail)
+      tailAndByteCount = (byteCount &+ 4) &<< 56
+    }
+  }
+
+  public mutating func append(bits: Int64) {
+    append(UInt64(bitPattern: bits))
+  }
+
+  public mutating func append(bits: UInt64) {
+    if byteCount & 4 == 0 {
+      assert(byteCount & 7 == 0 && tail == 0)
+      compress(bits)
+      tailAndByteCount = tailAndByteCount &+ (8 &<< 56)
+    } else {
+      assert(byteCount & 3 == 0)
+      compress((bits &<< 32) | tail)
+      tailAndByteCount = ((byteCount &+ 8) &<< 56) | (bits &>> 32)
+    }
+  }
+
+  public mutating func finalize(
+    tailBytes: UInt64,
+    tailByteCount: Int
+  ) -> UInt64 {
+    assert(tailByteCount >= 0)
+    assert(tailByteCount < 8 - (byteCount & 7))
+    assert(tailBytes >> (tailByteCount << 3) == 0)
+    let count = UInt64(_truncatingBits: tailByteCount._lowWord)
+    let currentByteCount = byteCount & 7
+    tailAndByteCount |= (tailBytes &<< (currentByteCount &<< 3))
+    tailAndByteCount = tailAndByteCount &+ (count &<< 56)
+    return finalize()
+  }
+
+  public mutating func finalize() -> UInt64 {
+    compress(tailAndByteCount)
+
+    self.state.v2 ^= 0xff
+
+    for _ in 0..<4 {
+      Rounds.sipRound(v0: &self.state.v0, v1: &self.state.v1,
+                      v2: &self.state.v2, v3: &self.state.v3)
+    }
+
+    return self.state.v0 ^ self.state.v1 ^ self.state.v2 ^ self.state.v3
+  }
+}
+
+// MARK: Utility Functions
+
+private func extendHostToLittle(
+  _ buf: UnsafeRawBufferPointer, start: Int, length: UInt64) -> UInt64 {
+  assert(length < 8)
+  var index = 0
+  var out: UInt64 = 0
+  if index + 3 < length {
+    out = UInt64(buf.load(fromByteOffset: start + index, as: UInt32.self))
+    index += 4
+  }
+  if index + 1 < length {
+    out |= UInt64(buf.load(fromByteOffset: start + index, as: UInt16.self)) << (index * 8)
+    index += 2
+  }
+  if index < length {
+    out |= buf.load(fromByteOffset: start + index, as: UInt64.self) << (index * 8)
+    index += 1
+  }
+  assert(index == length)
+  return out
+}
+
+private func rotateLeft(_ value: UInt64, by amount: UInt64) -> UInt64 {
+  return (value &<< amount) | (value &>> (64 - amount))
+}


### PR DESCRIPTION
### What's in this pull request?

- Adds a new library, libBoring,  to separate data structures needed for the dependency graph work in #88.
- Adds a copy of the `Hasher` protocol that's pending in Swift evolution.  The hope is we remove our copy of it when the proposal is accepted
- Implement SipHash24 as a first stable hasher