### PR TITLE
Don't Inline Outside The Optimizer

### DIFF
--- a/Sources/Mantle/Normalize.swift
+++ b/Sources/Mantle/Normalize.swift
@@ -244,6 +244,9 @@ extension TypeChecker {
     guard !ps.isEmpty else {
       return result
     }
+    guard es.count >= ps.count else {
+      return ClauseMatch.failure(.fail(()))
+    }
     var idx = 0
     var arguments = [TT]()
     arguments.reserveCapacity(ps.count)

--- a/Sources/Mesosphere/Patterns.swift
+++ b/Sources/Mesosphere/Patterns.swift
@@ -325,10 +325,11 @@ extension GIRGenFunction {
       }
       let (newParent, bodyVal) = self.emitRValue(bb, body)
       _ = self.B.createApply(newParent, retParam, [bodyVal])
-    case let .apply(head, args):
+    case let .apply(head, _):
       switch head {
       case .definition(_):
-        fatalError()
+        let (newParent, bodyVal) = self.emitRValue(bb, body)
+        _ = self.B.createApply(newParent, retParam, [bodyVal])
       case let .meta(mv):
         guard let bind = self.tc.signature.lookupMetaBinding(mv) else {
           fatalError()

--- a/Sources/OuterCore/GIRWriter.swift
+++ b/Sources/OuterCore/GIRWriter.swift
@@ -16,8 +16,8 @@ extension GIRModule {
     stream.write("\n")
     var visited = Set<Continuation>()
     for cont in self.continuations {
-      guard visited.insert(cont).inserted else { continue }
-      let scope = Scope(cont)
+      guard !visited.contains(cont) else { continue }
+      let scope = Scope(cont, visited)
       scope.dump()
       visited.formUnion(scope.continuations)
     }

--- a/Sources/OuterCore/Schedule.swift
+++ b/Sources/OuterCore/Schedule.swift
@@ -46,7 +46,7 @@ final class Schedule {
     self.tag = tag
 
     var i = 0
-    for n in scope.entry.reversePostOrder {
+    for n in scope.reversePostOrder {
       defer { i += 1 }
       self.blocks.append(Block(n, [], i))
       self.indices[n] = i

--- a/Sources/Seismography/Continuation.swift
+++ b/Sources/Seismography/Continuation.swift
@@ -10,7 +10,7 @@ public struct ParameterSemantics {
   var mustDestroy: Bool
 }
 
-public final class Continuation: Value, Graph {
+public final class Continuation: Value, GraphNode {
   public private(set) var parameters = [Parameter]()
   public private(set) var destroys = [DestroyValueOp]()
 

--- a/Tests/Mesosphere/switch-dispatch.silt
+++ b/Tests/Mesosphere/switch-dispatch.silt
@@ -154,3 +154,28 @@ maranget _  _  tt = four
 -- CHECK:   %24 = data_init switch-dispatch.Index ; switch-dispatch.one
 -- CHECK:   apply %3(%24) : (switch-dispatch.Index) -> _
 -- CHECK: } -- end gir function switch-dispatch.maranget
+
+if_then_else_ : Bool -> Bool -> Bool -> Bool
+if tt then x else _ = x
+if ff then _ else x = x
+-- CHECK: @switch-dispatch.if_then_else_ : (switch-dispatch.Bool ; switch-dispatch.Bool ; switch-dispatch.Bool) -> (switch-dispatch.Bool) -> _ {
+-- CHECK: bb0(%0 : switch-dispatch.Bool; %1 : switch-dispatch.Bool; %2 : switch-dispatch.Bool; %3 : (switch-dispatch.Bool) -> _):
+-- CHECK:   %4 = function_ref @bb2
+-- CHECK:   %5 = function_ref @bb1
+-- CHECK:   switch_constr %0 : switch-dispatch.Bool ; switch-dispatch.tt : %4 ; switch-dispatch.ff : %5
+-- CHECK: bb1:
+-- CHECK:   apply %3(%2) : (switch-dispatch.Bool) -> _
+-- CHECK: bb2:
+-- CHECK:   apply %3(%1) : (switch-dispatch.Bool) -> _
+-- CHECK: } -- end gir function switch-dispatch.if_then_else_
+
+_?_::_ : Bool -> Bool -> Bool -> Bool
+cond ? t :: f = if cond then t else f
+-- CHECK: @switch-dispatch._?_::_ : (switch-dispatch.Bool ; switch-dispatch.Bool ; switch-dispatch.Bool) -> (switch-dispatch.Bool) -> _ {
+-- CHECK: bb0(%0 : switch-dispatch.Bool; %1 : switch-dispatch.Bool; %2 : switch-dispatch.Bool; %3 : (switch-dispatch.Bool) -> _):
+-- CHECK:   %4 = function_ref @switch-dispatch.if_then_else_
+-- CHECK:   %5 = function_ref @bb1
+-- CHECK:   apply %4(%0 ; %1 ; %2 ; %5) : (switch-dispatch.Bool ; switch-dispatch.Bool ; switch-dispatch.Bool) -> (switch-dispatch.Bool) -> _
+-- CHECK: bb1(%7 : switch-dispatch.Bool):
+-- CHECK:   apply %3(%7) : (switch-dispatch.Bool) -> _
+-- CHECK: } -- end gir function switch-dispatch._?_::_


### PR DESCRIPTION
### What's in this pull request?

Two premature inlining bugs at two different levels of the compiler:

- In the Mantle, the typechecker was eagerly selecting the first clause it saw if it tried elimination by pattern matching and didn't have enough arguments.  This would cause it to inline the body of the clause and keep going.  Cut off pattern elimination in this case.
- In the OuterCore, traversals can't tell the difference between continuations outside their scope and inside their scope.  Add a whitelist and move the RPO API to scopes where it should belong.