### PR TITLE
Add contextual overloading

### DIFF
--- a/Sources/Mantle/Check.swift
+++ b/Sources/Mantle/Check.swift
@@ -455,7 +455,12 @@ extension TypeChecker where PhaseState == CheckPhaseState {
           fatalError()
         }
         return (.absurd, type)
-      case let .constructor(dataCon, synPats):
+      case let .constructor(dataConSet, synPats):
+        guard
+          let dataCon = self.disambiguateConstructor(dataConSet, patType)
+        else {
+          fatalError()
+        }
         // Use the data constructor to locate back up the parent so we can
         // retrieve its argument telescope.
         guard let data = self.signature.lookupDefinition(dataCon) else {

--- a/Sources/Mantle/Normalize.swift
+++ b/Sources/Mantle/Normalize.swift
@@ -179,6 +179,20 @@ extension TypeChecker {
     return pats
   }
 
+  func disambiguateConstructor(
+    _ set: [QualifiedName], _ ty: Type<TT>) -> QualifiedName? {
+    precondition(!set.isEmpty)
+    guard set.count > 1 else {
+      return set[0]
+    }
+    switch ty {
+    case let .apply(.definition(name), _):
+      return QualifiedName(cons: set[0].name, name.key)
+    default:
+      return nil
+    }
+  }
+
   func matchingConstructors(
     _ name: Opened<QualifiedName, TT>, _ cs: [QualifiedName], _ es: [Elim<TT>]
   ) -> [Pattern] {

--- a/Sources/Mantle/SemaDiagnostics.swift
+++ b/Sources/Mantle/SemaDiagnostics.swift
@@ -32,4 +32,13 @@ extension Diagnostic.Message {
       possible valid pattern: '\(pat)'
       """)
   }
+
+  static func useOfAmbiguousConstructor(_ name: Name) -> Diagnostic.Message {
+    return Diagnostic.Message(.error, "use of ambiguous constructor '\(name)'")
+  }
+
+  static func ambiguousConstructorCandidate(
+    _ name: QualifiedName) -> Diagnostic.Message {
+    return Diagnostic.Message(.note, "candidate constructor: '\(name)'")
+  }
 }

--- a/Sources/Moho/Name.swift
+++ b/Sources/Moho/Name.swift
@@ -9,7 +9,7 @@ import Lithosphere
 
 /// A internalized representation of an unqualified name.
 public struct Name: Equatable, Comparable, Hashable, CustomStringConvertible {
-  let syntax: TokenSyntax
+  public let syntax: TokenSyntax
   let string: String
 
   /// Create a `Name` by extracting it from a `TokenSyntax` node.
@@ -38,8 +38,8 @@ public struct Name: Equatable, Comparable, Hashable, CustomStringConvertible {
 /// A sequence of unqualified names forming a unique named scope under which
 /// declarations may be qualified.
 public struct QualifiedName: Equatable, Hashable, CustomStringConvertible {
-  let name: Name
-  let module: [Name]
+  public let name: Name
+  public let module: [Name]
 
   public init() {
     self.name = Name(name: TokenSyntax(.identifier("")))
@@ -99,7 +99,7 @@ public struct QualifiedName: Equatable, Hashable, CustomStringConvertible {
   }
 
   public var description: String {
-    var pieces = self.module.map { $0.description }
+    var pieces = self.module.reversed().map { $0.description }
     pieces.append(name.description)
     return pieces.joined(separator: ".")
   }

--- a/Sources/Moho/Syntax.swift
+++ b/Sources/Moho/Syntax.swift
@@ -191,7 +191,7 @@ public enum DeclaredPattern: CustomStringConvertible {
   /// foo [] x y          = ...
   /// foo (_::_ x xs) y z = ...
   /// ```
-  case constructor(QualifiedName, [DeclaredPattern])
+  case constructor([QualifiedName], [DeclaredPattern])
   /// An uninhabited pattern.
   ///
   /// ```
@@ -254,7 +254,7 @@ public indirect enum Expr: Equatable, CustomStringConvertible {
   /// that may depend on those variables.
   case lambda((Name, Expr), Expr)
   /// A type constructor for a term.
-  case constructor(QualifiedName, [Expr])
+  case constructor(QualifiedName, [QualifiedName], [Expr])
   /// The "Type" sort.
   ///
   /// Yeah, it's probably not a good idea to call a sort "Type", but it's better
@@ -338,7 +338,7 @@ public indirect enum Expr: Equatable, CustomStringConvertible {
       return "let \(declDesc) in \(expr)"
     case let .equal(eqTy, lhs, rhs):
       return "\(lhs) =(\(eqTy))= \(rhs)"
-    case let .constructor(openTm, args):
+    case let .constructor(_, openTm, args):
       return "\(openTm)(\(args.map({$0.description}).joined(separator: ", ")))"
     case let .apply(head, elims):
       switch head {

--- a/Tests/Mesosphere/dispatch-nested.silt
+++ b/Tests/Mesosphere/dispatch-nested.silt
@@ -14,7 +14,7 @@ suc n + m = suc (n + m)
 -- CHECK-GIR: bb0(%0 : dispatch-nested.Nat; %1 : dispatch-nested.Nat; %2 : (dispatch-nested.Nat) -> _):
 -- CHECK-GIR:   %3 = function_ref @bb2
 -- CHECK-GIR:   %4 = function_ref @bb1
--- CHECK-GIR:   switch_constr %0 : dispatch-nested.Nat ; dispatch-nested.zero : %3 ; dispatch-nested.suc : %4
+-- CHECK-GIR:   switch_constr %0 : dispatch-nested.Nat ; dispatch-nested.Nat.zero : %3 ; dispatch-nested.Nat.suc : %4
 -- CHECK-GIR: bb1(%6 : dispatch-nested.Nat):
 -- CHECK-GIR:   %7 = function_ref @bb0
 -- CHECK-GIR:   %8 = function_ref @bb3
@@ -26,7 +26,7 @@ suc n + m = suc (n + m)
 -- CHECK-GIR:   apply %2(%10) : (dispatch-nested.Nat) -> _
 -- CHECK-GIR: bb3(%14 : dispatch-nested.Nat):
 -- CHECK-GIR:   %15 = copy_value %14
--- CHECK-GIR:   %16 = data_init dispatch-nested.Nat ; dispatch-nested.suc ; %15
+-- CHECK-GIR:   %16 = data_init dispatch-nested.Nat ; dispatch-nested.Nat.suc ; %15
 -- CHECK-GIR:   apply %2(%16) : (dispatch-nested.Nat) -> _
 -- CHECK-GIR: } -- end gir function dispatch-nested._+_
 
@@ -48,21 +48,21 @@ doThing (ascii b) = b
 -- CHECK-GIR: bb0(%0 : dispatch-nested.Char; %1 : (dispatch-nested.Byte) -> _):
 -- CHECK-GIR:   %2 = function_ref @bb2                          -- user: %4
 -- CHECK-GIR:   %3 = function_ref @bb1                          -- user: %4
--- CHECK-GIR:   switch_constr %0 : dispatch-nested.Char ; dispatch-nested.eof : %2 ; dispatch-nested.ascii : %3
+-- CHECK-GIR:   switch_constr %0 : dispatch-nested.Char ; dispatch-nested.Char.eof : %2 ; dispatch-nested.Char.ascii : %3
 -- CHECK-GIR: bb1(%5 : dispatch-nested.Byte):
 -- CHECK-GIR:   %6 = copy_value %5
 -- CHECK-GIR:   destroy_value %0
 -- CHECK-GIR:   apply %1(%6) : (dispatch-nested.Byte) -> _
 -- CHECK-GIR: bb2:
--- CHECK-GIR:   %9 = data_init dispatch-nested.Bool ; dispatch-nested.false
--- CHECK-GIR:   %10 = data_init dispatch-nested.Bool ; dispatch-nested.false
--- CHECK-GIR:   %11 = data_init dispatch-nested.Bool ; dispatch-nested.false
--- CHECK-GIR:   %12 = data_init dispatch-nested.Bool ; dispatch-nested.false
--- CHECK-GIR:   %13 = data_init dispatch-nested.Bool ; dispatch-nested.false
--- CHECK-GIR:   %14 = data_init dispatch-nested.Bool ; dispatch-nested.false
--- CHECK-GIR:   %15 = data_init dispatch-nested.Bool ; dispatch-nested.false
--- CHECK-GIR:   %16 = data_init dispatch-nested.Bool ; dispatch-nested.false
--- CHECK-GIR:   %17 = data_init dispatch-nested.Byte ; dispatch-nested.byte ; %9 ; %10 ; %11 ; %12 ; %13 ; %14 ; %15 ; %16
+-- CHECK-GIR:   %9 = data_init dispatch-nested.Bool ; dispatch-nested.Bool.false
+-- CHECK-GIR:   %10 = data_init dispatch-nested.Bool ; dispatch-nested.Bool.false
+-- CHECK-GIR:   %11 = data_init dispatch-nested.Bool ; dispatch-nested.Bool.false
+-- CHECK-GIR:   %12 = data_init dispatch-nested.Bool ; dispatch-nested.Bool.false
+-- CHECK-GIR:   %13 = data_init dispatch-nested.Bool ; dispatch-nested.Bool.false
+-- CHECK-GIR:   %14 = data_init dispatch-nested.Bool ; dispatch-nested.Bool.false
+-- CHECK-GIR:   %15 = data_init dispatch-nested.Bool ; dispatch-nested.Bool.false
+-- CHECK-GIR:   %16 = data_init dispatch-nested.Bool ; dispatch-nested.Bool.false
+-- CHECK-GIR:   %17 = data_init dispatch-nested.Byte ; dispatch-nested.Byte.byte ; %9 ; %10 ; %11 ; %12 ; %13 ; %14 ; %15 ; %16
 -- CHECK-GIR:   apply %1(%17) : (dispatch-nested.Byte) -> _
 -- CHECK-GIR: } -- end gir function dispatch-nested.doThing
 

--- a/Tests/Mesosphere/switch-dispatch.silt
+++ b/Tests/Mesosphere/switch-dispatch.silt
@@ -20,13 +20,13 @@ dispatch ff = ff
 -- CHECK: bb0(%0 : switch-dispatch.Bool; %1 : (switch-dispatch.Bool) -> _):
 -- CHECK:   %2 = function_ref @bb2
 -- CHECK:   %3 = function_ref @bb1
--- CHECK:   switch_constr %0 : switch-dispatch.Bool ; switch-dispatch.tt : %2 ; switch-dispatch.ff : %3
+-- CHECK:   switch_constr %0 : switch-dispatch.Bool ; switch-dispatch.Bool.tt : %2 ; switch-dispatch.Bool.ff : %3
 -- CHECK: bb1:
--- CHECK:   %5 = data_init switch-dispatch.Bool ; switch-dispatch.ff
+-- CHECK:   %5 = data_init switch-dispatch.Bool ; switch-dispatch.Bool.ff
 -- CHECK:   destroy_value %0
 -- CHECK:   apply %1(%5) : (switch-dispatch.Bool) -> _
 -- CHECK: bb2:
--- CHECK:   %8 = data_init switch-dispatch.Bool ; switch-dispatch.tt
+-- CHECK:   %8 = data_init switch-dispatch.Bool ; switch-dispatch.Bool.tt
 -- CHECK:   destroy_value %0
 -- CHECK:   apply %1(%8) : (switch-dispatch.Bool) -> _
 -- CHECK: } -- end gir function switch-dispatch.dispatch
@@ -40,32 +40,32 @@ and ff ff = ff
 -- CHECK: bb0(%0 : switch-dispatch.Bool; %1 : switch-dispatch.Bool; %2 : (switch-dispatch.Bool) -> _):
 -- CHECK:   %3 = function_ref @bb4
 -- CHECK:   %4 = function_ref @bb1
--- CHECK:   switch_constr %0 : switch-dispatch.Bool ; switch-dispatch.tt : %3 ; switch-dispatch.ff : %4
+-- CHECK:   switch_constr %0 : switch-dispatch.Bool ; switch-dispatch.Bool.tt : %3 ; switch-dispatch.Bool.ff : %4
 -- CHECK: bb1:
 -- CHECK:   %6 = function_ref @bb3
 -- CHECK:   %7 = function_ref @bb2
--- CHECK:   switch_constr %1 : switch-dispatch.Bool ; switch-dispatch.tt : %6 ; switch-dispatch.ff : %7
+-- CHECK:   switch_constr %1 : switch-dispatch.Bool ; switch-dispatch.Bool.tt : %6 ; switch-dispatch.Bool.ff : %7
 -- CHECK: bb2:
--- CHECK:   %9 = data_init switch-dispatch.Bool ; switch-dispatch.ff
+-- CHECK:   %9 = data_init switch-dispatch.Bool ; switch-dispatch.Bool.ff
 -- CHECK:   destroy_value %1
 -- CHECK:   destroy_value %0
 -- CHECK:   apply %2(%9)
 -- CHECK: bb3:
--- CHECK:   %13 = data_init switch-dispatch.Bool ; switch-dispatch.ff
+-- CHECK:   %13 = data_init switch-dispatch.Bool ; switch-dispatch.Bool.ff
 -- CHECK:   destroy_value %1
 -- CHECK:   destroy_value %0
 -- CHECK:   apply %2(%13)
 -- CHECK: bb4:
 -- CHECK:   %17 = function_ref @bb6
 -- CHECK:   %18 = function_ref @bb5
--- CHECK:   switch_constr %1 : switch-dispatch.Bool ; switch-dispatch.tt : %17 ; switch-dispatch.ff : %18
+-- CHECK:   switch_constr %1 : switch-dispatch.Bool ; switch-dispatch.Bool.tt : %17 ; switch-dispatch.Bool.ff : %18
 -- CHECK: bb5:
--- CHECK:   %20 = data_init switch-dispatch.Bool ; switch-dispatch.ff
+-- CHECK:   %20 = data_init switch-dispatch.Bool ; switch-dispatch.Bool.ff
 -- CHECK:   destroy_value %1
 -- CHECK:   destroy_value %0
 -- CHECK:   apply %2(%20) : (switch-dispatch.Bool) -> _
 -- CHECK: bb6:
--- CHECK:   %24 = data_init switch-dispatch.Bool ; switch-dispatch.tt
+-- CHECK:   %24 = data_init switch-dispatch.Bool ; switch-dispatch.Bool.tt
 -- CHECK:   destroy_value %1
 -- CHECK:   destroy_value %0
 -- CHECK:   apply %2(%24) : (switch-dispatch.Bool) -> _
@@ -81,32 +81,32 @@ or ff ff = ff
 -- CHECK: bb0(%0 : switch-dispatch.Bool; %1 : switch-dispatch.Bool; %2 : (switch-dispatch.Bool) -> _):
 -- CHECK:   %3 = function_ref @bb4
 -- CHECK:   %4 = function_ref @bb1
--- CHECK:   switch_constr %0 : switch-dispatch.Bool ; switch-dispatch.tt : %3 ; switch-dispatch.ff : %4
+-- CHECK:   switch_constr %0 : switch-dispatch.Bool ; switch-dispatch.Bool.tt : %3 ; switch-dispatch.Bool.ff : %4
 -- CHECK: bb1:
 -- CHECK:   %6 = function_ref @bb3
 -- CHECK:   %7 = function_ref @bb2
--- CHECK:   switch_constr %1 : switch-dispatch.Bool ; switch-dispatch.tt : %6 ; switch-dispatch.ff : %7
+-- CHECK:   switch_constr %1 : switch-dispatch.Bool ; switch-dispatch.Bool.tt : %6 ; switch-dispatch.Bool.ff : %7
 -- CHECK: bb2:
--- CHECK:   %9 = data_init switch-dispatch.Bool ; switch-dispatch.ff
+-- CHECK:   %9 = data_init switch-dispatch.Bool ; switch-dispatch.Bool.ff
 -- CHECK:   destroy_value %1
 -- CHECK:   destroy_value %0
 -- CHECK:   apply %2(%9) : (switch-dispatch.Bool) -> _
 -- CHECK: bb3:
--- CHECK:   %13 = data_init switch-dispatch.Bool ; switch-dispatch.tt
+-- CHECK:   %13 = data_init switch-dispatch.Bool ; switch-dispatch.Bool.tt
 -- CHECK:   destroy_value %1
 -- CHECK:   destroy_value %0
 -- CHECK:   apply %2(%13) : (switch-dispatch.Bool) -> _
 -- CHECK: bb4:
 -- CHECK:   %17 = function_ref @bb6
 -- CHECK:   %18 = function_ref @bb5
--- CHECK:   switch_constr %1 : switch-dispatch.Bool ; switch-dispatch.tt : %17 ; switch-dispatch.ff : %18
+-- CHECK:   switch_constr %1 : switch-dispatch.Bool ; switch-dispatch.Bool.tt : %17 ; switch-dispatch.Bool.ff : %18
 -- CHECK: bb5:
--- CHECK:   %20 = data_init switch-dispatch.Bool ; switch-dispatch.tt
+-- CHECK:   %20 = data_init switch-dispatch.Bool ; switch-dispatch.Bool.tt
 -- CHECK:   destroy_value %1
 -- CHECK:   destroy_value %0
 -- CHECK:   apply %2(%20) : (switch-dispatch.Bool) -> _
 -- CHECK: bb6:
--- CHECK:   %24 = data_init switch-dispatch.Bool ; switch-dispatch.tt
+-- CHECK:   %24 = data_init switch-dispatch.Bool ; switch-dispatch.Bool.tt
 -- CHECK:   destroy_value %1
 -- CHECK:   destroy_value %0
 -- CHECK:   apply %2(%24) : (switch-dispatch.Bool) -> _
@@ -129,9 +129,9 @@ and2 ff b = ff
 -- CHECK: bb0(%0 : switch-dispatch.Bool; %1 : switch-dispatch.Bool; %2 : (switch-dispatch.Bool) -> _):
 -- CHECK:   %3 = function_ref @bb2
 -- CHECK:   %4 = function_ref @bb1
--- CHECK:   switch_constr %0 : switch-dispatch.Bool ; switch-dispatch.tt : %3 ; switch-dispatch.ff : %4
+-- CHECK:   switch_constr %0 : switch-dispatch.Bool ; switch-dispatch.Bool.tt : %3 ; switch-dispatch.Bool.ff : %4
 -- CHECK: bb1:
--- CHECK:   %6 = data_init switch-dispatch.Bool ; switch-dispatch.ff
+-- CHECK:   %6 = data_init switch-dispatch.Bool ; switch-dispatch.Bool.ff
 -- CHECK:   destroy_value %1
 -- CHECK:   destroy_value %0
 -- CHECK:   apply %2(%6) : (switch-dispatch.Bool) -> _
@@ -151,29 +151,29 @@ maranget _  _  tt = four
 -- CHECK: bb0(%0 : switch-dispatch.Bool; %1 : switch-dispatch.Bool; %2 : switch-dispatch.Bool; %3 : (switch-dispatch.Index) -> _):
 -- CHECK:   %4 = function_ref @bb6
 -- CHECK:   %5 = function_ref @bb1
--- CHECK:   switch_constr %1 : switch-dispatch.Bool ; switch-dispatch.ff : %4 ; default : %5
+-- CHECK:   switch_constr %1 : switch-dispatch.Bool ; switch-dispatch.Bool.ff : %4 ; default : %5
 -- CHECK: bb1:
 -- CHECK:   %7 = function_ref @bb5
 -- CHECK:   %8 = function_ref @bb2
--- CHECK:   switch_constr %0 : switch-dispatch.Bool ; switch-dispatch.ff : %7 ; default : %8
+-- CHECK:   switch_constr %0 : switch-dispatch.Bool ; switch-dispatch.Bool.ff : %7 ; default : %8
 -- CHECK: bb2:
 -- CHECK:   %10 = function_ref @bb4
 -- CHECK:   %11 = function_ref @bb3
--- CHECK:   switch_constr %2 : switch-dispatch.Bool ; switch-dispatch.ff : %10 ; switch-dispatch.tt : %11
+-- CHECK:   switch_constr %2 : switch-dispatch.Bool ; switch-dispatch.Bool.ff : %10 ; switch-dispatch.Bool.tt : %11
 -- CHECK: bb3:
--- CHECK:   %13 = data_init switch-dispatch.Index ; switch-dispatch.four
+-- CHECK:   %13 = data_init switch-dispatch.Index ; switch-dispatch.Index.four
 -- CHECK:   destroy_value %2
 -- CHECK:   destroy_value %1
 -- CHECK:   destroy_value %0
 -- CHECK:   apply %3(%13) : (switch-dispatch.Index) -> _
 -- CHECK: bb4:
--- CHECK:   %18 = data_init switch-dispatch.Index ; switch-dispatch.three
+-- CHECK:   %18 = data_init switch-dispatch.Index ; switch-dispatch.Index.three
 -- CHECK:   destroy_value %2
 -- CHECK:   destroy_value %1
 -- CHECK:   destroy_value %0
 -- CHECK:   apply %3(%18) : (switch-dispatch.Index) -> _
 -- CHECK: bb5:
--- CHECK:   %23 = data_init switch-dispatch.Index ; switch-dispatch.two
+-- CHECK:   %23 = data_init switch-dispatch.Index ; switch-dispatch.Index.two
 -- CHECK:   destroy_value %2
 -- CHECK:   destroy_value %1
 -- CHECK:   destroy_value %0
@@ -181,15 +181,15 @@ maranget _  _  tt = four
 -- CHECK: bb6:
 -- CHECK:   %28 = function_ref @bb8
 -- CHECK:   %29 = function_ref @bb7
--- CHECK:   switch_constr %2 : switch-dispatch.Bool ; switch-dispatch.tt : %28 ; switch-dispatch.ff : %29
+-- CHECK:   switch_constr %2 : switch-dispatch.Bool ; switch-dispatch.Bool.tt : %28 ; switch-dispatch.Bool.ff : %29
 -- CHECK: bb7:
--- CHECK:   %31 = data_init switch-dispatch.Index ; switch-dispatch.three
+-- CHECK:   %31 = data_init switch-dispatch.Index ; switch-dispatch.Index.three
 -- CHECK:   destroy_value %2
 -- CHECK:   destroy_value %1
 -- CHECK:   destroy_value %0
 -- CHECK:   apply %3(%31) : (switch-dispatch.Index) -> _
 -- CHECK: bb8:
--- CHECK:   %36 = data_init switch-dispatch.Index ; switch-dispatch.one
+-- CHECK:   %36 = data_init switch-dispatch.Index ; switch-dispatch.Index.one
 -- CHECK:   destroy_value %2
 -- CHECK:   destroy_value %1
 -- CHECK:   destroy_value %0
@@ -203,7 +203,7 @@ if ff then _ else x = x
 -- CHECK: bb0(%0 : switch-dispatch.Bool; %1 : switch-dispatch.Bool; %2 : switch-dispatch.Bool; %3 : (switch-dispatch.Bool) -> _):
 -- CHECK:   %4 = function_ref @bb2
 -- CHECK:   %5 = function_ref @bb1
--- CHECK:   switch_constr %0 : switch-dispatch.Bool ; switch-dispatch.tt : %4 ; switch-dispatch.ff : %5
+-- CHECK:   switch_constr %0 : switch-dispatch.Bool ; switch-dispatch.Bool.tt : %4 ; switch-dispatch.Bool.ff : %5
 -- CHECK: bb1:
 -- CHECK:   %7 = copy_value %2
 -- CHECK:   destroy_value %2

--- a/Tests/TypeCheck/absurd.silt
+++ b/Tests/TypeCheck/absurd.silt
@@ -13,5 +13,5 @@ magic ()
 no-magic : {A : Type} -> (x : NotEmpty) -> A 
 no-magic ()
 -- expected-error@-1 {{absurd pattern of type 'absurd.NotEmpty' in clause should not have possible valid patterns}}
--- expected-note@-2 {{possible valid pattern: 'absurd.inhabited'}}
+-- expected-note@-2 {{possible valid pattern: 'absurd.NotEmpty.inhabited'}}
 

--- a/Tests/TypeCheck/overload.silt
+++ b/Tests/TypeCheck/overload.silt
@@ -1,0 +1,51 @@
+-- RUN: %silt --verify typecheck %s
+
+module overload where
+
+data Nat : Type where
+  z : Nat
+  s : Nat
+
+data Bool : Type where
+  tt : Bool
+  ff : Bool
+
+data List (A : Type) : Type where
+  []   : List A
+  _::_ : A -> List A -> List A
+
+data Vector (A : Type) : Type where
+  []   : Vector A
+  _::_ : A -> Vector A -> Vector A
+
+data Array (A : Type) : Type where
+  []   : Array A
+  _::_ : A -> Array A -> Array A
+
+foo : Array Nat
+foo = []
+
+bar : List Nat
+bar = []
+
+ty : Type
+ty = Vector Nat
+
+baz : ty
+baz = []
+
+ty2 : Type -> Type
+ty2 = Vector
+
+quux : ty2 Nat
+quux = []
+
+ty3 : Bool -> Type
+ty3 tt = Vector Nat
+ty3 ff = Array Nat
+
+quuz : (b : Bool) -> ty3 b
+quuz = [] -- expected-error {{use of ambiguous constructor '[]'}}
+-- expected-note@-1 {{candidate constructor: 'overload.List.[]'}}
+-- expected-note@-2 {{candidate constructor: 'overload.Vector.[]'}}
+-- expected-note@-3 {{candidate constructor: 'overload.Array.[]'}}


### PR DESCRIPTION
### What's in this pull request?

Refactor ScopeCheck to not drop namespaces and accept overloads for constructors.  These overloads are required to be disambiguated by contextual types at elaboration time.  We will not be introducing disjunctions into the constraint system!

Haven't touched records, but they will go through the same treatment in a future patch.