### PR TITLE
Add filtering option to lite

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     .package(url: "https://github.com/llvm-swift/Symbolic.git", from: "0.0.1"),
     .package(url: "https://github.com/onevcat/Rainbow.git", from: "3.0.0"),
     .package(url: "https://github.com/llvm-swift/LLVMSwift.git", from: "0.3.0"),
-    .package(url: "https://github.com/llvm-swift/Lite.git", from: "0.0.3"),
+    .package(url: "https://github.com/llvm-swift/Lite.git", from: "0.0.11"),
     .package(url: "https://github.com/llvm-swift/PrettyStackTrace.git", from: "0.0.1"),
   ],
   targets: [


### PR DESCRIPTION
### What's in this pull request?

This uses the filtering option in Lite 0.0.11 to allow the test runner to filter just a few tests.

### Why merge this pull request?

As we grow more tests, it's more helpful to run a subset.

### What's worth discussing about this pull request?

Should we allow multiple filters?

### What downsides are there to merging this pull request?

None