### PR TITLE
Indirection

### DIFF
--- a/Sources/Mantle/Support.swift
+++ b/Sources/Mantle/Support.swift
@@ -457,7 +457,7 @@ public struct Meta: Comparable, Hashable, CustomStringConvertible {
   /// A `Binding` represents the term associated with a particular metavariable.
   public struct Binding {
     /// The arity of the given binding.
-    let arity: Int
+    public let arity: Int
     public let body: TT
 
     init(arity: Int, body: TT) {

--- a/Sources/Mesosphere/ManagedValue.swift
+++ b/Sources/Mesosphere/ManagedValue.swift
@@ -45,8 +45,10 @@ struct ManagedValue {
       return ManagedValue(value: value, cleanup: GGF.cleanupValue(value))
     case .address:
       let alloc = GGF.B.createAlloca(self.value.type)
-      let addr = GGF.B.createCopyAddress(self.value, to: alloc)
-      return ManagedValue(value: value, cleanup: GGF.cleanupAddress(addr))
+      let managedBuf = ManagedValue(value: alloc,
+                                    cleanup: GGF.cleanupAlloca(alloc))
+      let addr = GGF.B.createCopyAddress(self.value, to: managedBuf.value)
+      return ManagedValue(value: addr, cleanup: GGF.cleanupAddress(addr))
     }
   }
 

--- a/Sources/OuterCore/GIRWriter.swift
+++ b/Sources/OuterCore/GIRWriter.swift
@@ -341,10 +341,14 @@ extension GIRWriter: PrimOpVisitor {
     self.write(self.getID(of: op.value).description)
     self.write(" to ")
     self.write(self.getID(of: op.address).description)
+    self.write(" : ")
+    self.visitType(op.type)
   }
 
   public func visitDestroyAddressOp(_ op: DestroyAddressOp) {
     self.write(self.getID(of: op.value).description)
+    self.write(" : ")
+    self.visitType(op.value.type)
   }
 
   public func visitSwitchConstrOp(_ op: SwitchConstrOp) {
@@ -401,23 +405,45 @@ extension GIRWriter: PrimOpVisitor {
 }
 
 extension GIRWriter: TypeVisitor {
+  public func visitTypeCommon(_ type: GIRType) {
+    if type.category == .address {
+      self.write("*")
+    }
+  }
+
   public func visitGIRExprType(_ type: GIRExprType) {
+    self.visitTypeCommon(type)
     self.write(type.expr.diagnosticSourceText)
   }
-  public func visitTypeMetadataType(_ type: TypeMetadataType) {}
-  public func visitTypeType(_ type: TypeType) {}
-  public func visitArchetypeType(_ type: ArchetypeType) {}
-  public func visitParameterizedType(_ type: ParameterizedType) {}
+
+  public func visitTypeMetadataType(_ type: TypeMetadataType) {
+    self.visitTypeCommon(type)
+  }
+  public func visitTypeType(_ type: TypeType) {
+    self.visitTypeCommon(type)
+    self.write("Type")
+  }
+  public func visitArchetypeType(_ type: ArchetypeType) {
+    self.visitTypeCommon(type)
+    self.write(type.name)
+  }
+  public func visitParameterizedType(_ type: ParameterizedType) {
+    self.visitTypeCommon(type)
+  }
   public func visitDataType(_ type: DataType) {
+    self.visitTypeCommon(type)
     self.write(type.name)
   }
   public func visitBoxType(_ type: BoxType) {
+    self.visitTypeCommon(type)
     self.write(type.name)
   }
   public func visitRecordType(_ type: RecordType) {
+    self.visitTypeCommon(type)
     self.write(type.name)
   }
   public func visitFunctionType(_ type: FunctionType) {
+    self.visitTypeCommon(type)
     guard !type.arguments.isEmpty else {
       return self.visitType(type.returnType)
     }
@@ -429,14 +455,18 @@ extension GIRWriter: TypeVisitor {
     return self.visitType(type.returnType)
   }
   public func visitTupleType(_ type: TupleType) {
+    self.visitTypeCommon(type)
     self.write("(")
     self.interleave(type.elements,
                     { self.visitType($0) },
                     { self.write(" , ") })
     self.write(")")
   }
-  public func visitSubstitutedType(_ type: SubstitutedType) {}
+  public func visitSubstitutedType(_ type: SubstitutedType) {
+    self.visitTypeCommon(type)
+  }
   public func visitBottomType(_ type: BottomType) {
+    self.visitTypeCommon(type)
     self.write("_")
   }
 }

--- a/Sources/OuterCore/IRVerifier.swift
+++ b/Sources/OuterCore/IRVerifier.swift
@@ -33,8 +33,8 @@ public final class IRVerifier {
       return module.metadataType === type
     case let type as TypeType:
       return module.typeType === type
-    case let type as ArchetypeType:
-      return valueIsKnown(type.parent)
+    case _ as ArchetypeType:
+      return false
     case let type as SubstitutedType:
       guard valueIsKnown(type.substitutee) else { return false }
       for (arch, subst) in type.substitutions {

--- a/Sources/Seismography/Generic.swift
+++ b/Sources/Seismography/Generic.swift
@@ -1,0 +1,36 @@
+/// Generic.swift
+///
+/// Copyright 2018, The Silt Language Project.
+///
+/// This project is released under the MIT license, a copy of which is
+/// available in the repository.
+
+public final class GenericEnvironment {
+  public struct Key {
+    let depth: UInt
+    let index: UInt
+
+    public init(depth: UInt, index: UInt) {
+      self.depth = depth
+      self.index = index
+    }
+  }
+
+  let signature: GenericSignature
+
+  public init(signature: GenericSignature) {
+    self.signature = signature
+  }
+
+  public func find(_ k: Key) -> ArchetypeType? {
+    return self.signature.archetypes[Int(k.index)]
+  }
+}
+
+public final class GenericSignature {
+  let archetypes: [ArchetypeType]
+
+  public init(archetypes: [ArchetypeType]) {
+    self.archetypes = archetypes
+  }
+}

--- a/Sources/Seismography/PrimOp.swift
+++ b/Sources/Seismography/PrimOp.swift
@@ -38,6 +38,8 @@ public class PrimOp: Value {
     ///
     /// When the type of the source value is address-only, copies the address
     /// from the source value to the address at the destination value.
+    ///
+    /// Returns the destination's memory.
     case copyAddress = "copy_address"
 
     /// Destroys the value pointed to by the given address but does not

--- a/Sources/Seismography/Type.swift
+++ b/Sources/Seismography/Type.swift
@@ -112,22 +112,20 @@ public final class TypeType: GIRType {
 }
 
 public final class ArchetypeType: GIRType {
-  public unowned let parent: ParameterizedType
   public let index: Int
 
-  init(parent: ParameterizedType, index: Int) {
-    self.parent = parent
+  public init(index: Int) {
     self.index = index
-    super.init(name: "", type: TypeType.shared, category: .address)
+    super.init(name: "τ_\(index)", type: TypeType.shared, category: .address)
   }
 
   public override func equals(_ other: Value) -> Bool {
     guard let other = other as? ArchetypeType else { return false }
-    return parent == other.parent && index == other.index
+    return index == other.index
   }
 
   public override var hashValue: Int {
-    return ObjectIdentifier(parent).hashValue ^ index.hashValue ^ 0x374b2947
+    return index.hashValue ^ 0x374b2947
   }
 }
 
@@ -152,7 +150,7 @@ public class ParameterizedType: GIRType {
   }
 
   public func addParameter(name: String, type: GIRType) {
-    let archetype = ArchetypeType(parent: self, index: parameters.count)
+    let archetype = ArchetypeType(index: parameters.count)
     let value = NameAndType(name: name, type: type)
     parameters.append(Parameter(archetype: archetype, value: value))
   }

--- a/Tests/Mesosphere/dispatch-nested.silt
+++ b/Tests/Mesosphere/dispatch-nested.silt
@@ -19,20 +19,20 @@ suc n + m = suc (n + m)
 -- CHECK-GIR:   %7 = function_ref @bb0
 -- CHECK-GIR:   %8 = load_box %6 : @box dispatch-nested.Nat
 -- CHECK-GIR:   %9 = function_ref @bb3
--- CHECK-GIR:   destroy_value %1
--- CHECK-GIR:   destroy_value %0
 -- CHECK-GIR:   apply %7(%8 ; %1 ; %9) : (dispatch-nested.Nat ; dispatch-nested.Nat) -> (dispatch-nested.Nat) -> _
 -- CHECK-GIR: bb2:
--- CHECK-GIR:   %13 = copy_value %1
+-- CHECK-GIR:   %11 = copy_value %1
 -- CHECK-GIR:   destroy_value %1
 -- CHECK-GIR:   destroy_value %0
--- CHECK-GIR:   apply %2(%13) : (dispatch-nested.Nat) -> _
--- CHECK-GIR: bb3(%17 : dispatch-nested.Nat):
--- CHECK-GIR:   %18 = copy_value %17
--- CHECK-GIR:   %19 = alloc_box dispatch-nested.Nat
--- CHECK-GIR:   %20 = store_box %18 to %19
--- CHECK-GIR:   %21 = data_init dispatch-nested.Nat ; dispatch-nested.Nat.suc ; %20
--- CHECK-GIR:   apply %2(%21) : (dispatch-nested.Nat) -> _
+-- CHECK-GIR:   apply %2(%11) : (dispatch-nested.Nat) -> _
+-- CHECK-GIR: bb3(%15 : dispatch-nested.Nat):
+-- CHECK-GIR:   %16 = copy_value %15
+-- CHECK-GIR:   %17 = alloc_box dispatch-nested.Nat
+-- CHECK-GIR:   %18 = store_box %16 to %17
+-- CHECK-GIR:   %19 = data_init dispatch-nested.Nat ; dispatch-nested.Nat.suc ; %18
+-- CHECK-GIR:   destroy_value %1
+-- CHECK-GIR:   destroy_value %0
+-- CHECK-GIR:   apply %2(%19) : (dispatch-nested.Nat) -> _
 -- CHECK-GIR: } -- end gir function dispatch-nested._+_
 
 data Bool : Type where

--- a/Tests/Mesosphere/poly.silt
+++ b/Tests/Mesosphere/poly.silt
@@ -1,0 +1,23 @@
+-- RUN: %silt %s --dump girgen 2>&1 | %FileCheck %s --prefixes CHECK-GIR
+
+-- CHECK-GIR: module poly where
+module poly where
+
+id : {A : Type} -> A -> A
+id x = x
+-- CHECK-GIR: @poly.id : (*Type ; *τ_0 ; *τ_0) -> (*τ_0) -> _ {
+-- CHECK-GIR: bb0(%0 : *Type; %1 : *τ_0; %2 : *τ_0; %3 : (*τ_0) -> _):
+-- CHECK-GIR:   %4 = copy_address %1 to %2 : *τ_0
+-- CHECK-GIR:   destroy_address %1 : *τ_0
+-- CHECK-GIR:   apply %3(%4) : (*τ_0) -> _
+-- CHECK-GIR: } -- end gir function poly.id
+
+const : {A B : Type} -> A -> B -> A
+const x _ = x
+-- CHECK-GIR: @poly.const : (*Type ; *Type ; *τ_0 ; *τ_1 ; *τ_0) -> (*τ_0) -> _ {
+-- CHECK-GIR: bb0(%0 : *Type; %1 : *Type; %2 : *τ_0; %3 : *τ_1; %4 : *τ_0; %5 : (*τ_0) -> _)
+-- CHECK-GIR:   %6 = copy_address %2 to %4 : *τ_0
+-- CHECK-GIR:   destroy_address %3 : *τ_1
+-- CHECK-GIR:   destroy_address %2 : *τ_0
+-- CHECK-GIR:   apply %5(%6) : (*τ_0) -> _
+-- CHECK-GIR: } -- end gir function poly.const


### PR DESCRIPTION
### What's in this pull request?

Start lowering generics as address-only values in GIR.

Doing this raised an interesting issue: Escaping an address value from the function is pretty tricky in CPS form.  Suppose we have the following function:

```silt
id : {A : Type} -> A -> A
id x = x
```

If we tried to naively compile this to GIR it would lead to something like this

```llvm
@id : (*Type ; *τ_0 ; *τ_0) -> (*τ_0) -> _ {
bb0(%0 : *Type; %1 : *τ_0; %2 : (*τ_0) -> _):
  %3 = alloca τ_0
  %4 = copy_address %1 to %3 : *τ_0
  destroy_address %1 : *τ_0
  apply %2(%4) : (*τ_0) -> _
} -- end gir function id
```

We can't be guaranteed that the return continuation isn't in the frame above ours, so the alloca may lead to garbage memory being handed back. On top of that, the continuation's destroy cannot know that we alloca'd this memory, so it would probably attempt to `free` it in the `destroy_address` it emits.  We need the allocation to be owned by the calling context instead.  So I've implemented an indirect return convention that blesses the parameter before the return parameter as an indirect return value.  This value is required to be store'd into by the callee then handed off to the return continuation.  Doing this guarantees the lifetime of our allocation, allows us to alloca in the calling frame, and simplifies reasoning about the lifetimes of parameters

This is the code we emit instead:

```llvm
@poly.id : (*Type ; *τ_0 ; *τ_0) -> (*τ_0) -> _ {
bb0(%0 : *Type; %1 : *τ_0; %2 : *τ_0; %3 : (*τ_0) -> _):
   %4 = copy_address %1 to %2 : *τ_0
   destroy_address %1 : *τ_0
   apply %3(%4) : (*τ_0) -> _
} -- end gir function poly.id
```