### PR TITLE
Extend Boring to act as a driver

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     .package(url: "https://github.com/llvm-swift/Symbolic.git", from: "0.0.1"),
     .package(url: "https://github.com/onevcat/Rainbow.git", from: "3.0.0"),
     .package(url: "https://github.com/llvm-swift/LLVMSwift.git", from: "0.3.0"),
-    .package(url: "https://github.com/llvm-swift/Lite.git", from: "0.0.11"),
+    .package(url: "https://github.com/llvm-swift/Lite.git", .branch("build-experiment2")),
     .package(url: "https://github.com/llvm-swift/PrettyStackTrace.git", from: "0.0.1"),
   ],
   targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -23,16 +23,16 @@ let package = Package(
       dependencies: ["Lithosphere"]),
     .target(
       name: "Boring",
-      dependencies: []),
+      dependencies: ["Drill", "Utility", "Mantle"]),
     .target(
       name: "Drill",
       dependencies: [
-        "Boring", "Lithosphere", "Crust", "Moho", "Mantle", "Seismography",
+        "Lithosphere", "Crust", "Moho", "Mantle", "Seismography",
         "Mesosphere", "OuterCore", "InnerCore", "Utility"
     ]),
     .target(
       name: "silt",
-      dependencies: ["Drill", "Utility", "Ferrite"]),
+      dependencies: ["Boring", "Utility"]),
     .target(
       name: "SyntaxGen",
       dependencies: ["Utility", "Lithosphere"]),

--- a/Sources/Boring/Frontend.swift
+++ b/Sources/Boring/Frontend.swift
@@ -1,0 +1,130 @@
+/// Frontend.swift
+///
+/// Copyright 2017-2018, The Silt Language Project.
+///
+/// This project is released under the MIT license, a copy of which is
+/// available in the repository.
+
+import Foundation
+import Basic
+import Utility
+import Mantle
+import Drill
+
+public final class FrontendToolOptions: SiltToolOptions {
+  public var mode: Mode = .compile
+  public var colorsEnabled: Bool = false
+  public var shouldPrintTiming: Bool = false
+  public var inputURLs: [Foundation.URL] = []
+  public var typeCheckerDebugOptions: TypeCheckerDebugOptions = []
+}
+
+extension Mode.VerifyLayer: StringEnumArgument {
+  public static var completion: ShellCompletion {
+    return ShellCompletion.values([
+      ("parse", "Verify the result of parsing the input file(s)"),
+      ("scopes", "Verify the result of scope checking the input file(s)"),
+    ])
+  }
+}
+
+extension Mode.DumpLayer: StringEnumArgument {
+  public static var completion: ShellCompletion {
+    return ShellCompletion.values([
+      (Mode.DumpLayer.tokens.rawValue,
+       "Dump the result of tokenizing the input file(s)"),
+      (Mode.DumpLayer.parse.rawValue,
+       "Dump the result of parsing the input file(s)"),
+      (Mode.DumpLayer.file.rawValue,
+       "Dump the result of parsing and reconstructing the input file(s)"),
+      (Mode.DumpLayer.shined.rawValue,
+       "Dump the result of shining the input file(s)"),
+      (Mode.DumpLayer.scopes.rawValue,
+       "Dump the result of scope checking the input file(s)"),
+    ])
+  }
+}
+
+public class SiltFrontendTool: SiltTool<FrontendToolOptions> {
+  public convenience init(args: [String]) {
+    self.init(
+      toolName: "frontend",
+      usage: "[options]",
+      overview: "Build sources into binary products",
+      args: args
+    )
+  }
+
+  override func runImpl() throws {
+    let invocation = Invocation(options: translateOptions())
+    if invocation.run() {
+      self.executionStatus = .failure
+    } else {
+      self.executionStatus = .success
+    }
+  }
+
+  private func translateOptions() -> Options {
+    return Options(
+      mode: self.options.mode,
+      colorsEnabled: self.options.colorsEnabled,
+      shouldPrintTiming: self.options.shouldPrintTiming,
+      inputURLs: self.options.inputURLs,
+      typeCheckerDebugOptions: self.options.typeCheckerDebugOptions)
+  }
+
+  override class func defineArguments(
+    parser: ArgumentParser,
+    binder: ArgumentBinder<FrontendToolOptions>
+  ) {
+    binder.bind(
+      option: parser.add(
+        option: "--dump",
+        kind: Mode.DumpLayer.self,
+        usage: "Dump the result of compiling up to a given layer"),
+      to: { opt, r in opt.mode = .dump(r) })
+    binder.bind(
+      option: parser.add(
+        option: "--verify",
+        kind: Mode.VerifyLayer.self,
+        usage: "Verify the result of compiling up to a given layer"),
+      to: { opt, r in opt.mode = .verify(r) })
+    binder.bind(
+      option: parser.add(option: "--color-diagnostics", kind: Bool.self),
+      to: { opt, r in opt.colorsEnabled = r })
+    binder.bind(
+      option: parser.add(option: "--debug-print-timing", kind: Bool.self),
+      to: { opt, r in opt.shouldPrintTiming = r })
+    binder.bind(
+      option: parser.add(option: "--debug-constraints", kind: Bool.self),
+      to: { opt, r in
+        if r {
+          opt.typeCheckerDebugOptions.insert(.debugConstraints)
+        }
+    })
+    binder.bind(
+      option: parser.add(option: "--debug-metas", kind: Bool.self),
+      to: { opt, r in
+        if r {
+          opt.typeCheckerDebugOptions.insert(.debugMetas)
+        }
+    })
+    binder.bind(
+      option: parser.add(option: "--debug-normalized-metas", kind: Bool.self),
+      to: { opt, r in
+        if r {
+          opt.typeCheckerDebugOptions.insert(.debugNormalizedMetas)
+        }
+    })
+    binder.bindArray(
+      positional: parser.add(
+        positional: "",
+        kind: [String].self,
+        usage: "One or more input file(s)",
+        completion: .filename),
+      to: { opt, fs in
+        let url = fs.map(URL.init(fileURLWithPath:))
+        return opt.inputURLs.append(contentsOf: url)
+    })
+  }
+}

--- a/Sources/Boring/Tool.swift
+++ b/Sources/Boring/Tool.swift
@@ -7,8 +7,8 @@
 
 import SPMLibc
 import Basic
-import enum POSIX.SystemError
 import Utility
+import POSIX
 
 public class SiltToolOptions {
   let verbosity: Int = Verbosity.concise.rawValue
@@ -116,9 +116,9 @@ public class SiltTool<Options: SiltToolOptions> {
   private static func exit(with status: ExecutionStatus) -> Never {
     switch status {
     case .success:
-      Darwin.exit(0)
+      POSIX.exit(0)
     case .failure:
-      Darwin.exit(1)
+      POSIX.exit(1)
     }
   }
 

--- a/Sources/Boring/Tool.swift
+++ b/Sources/Boring/Tool.swift
@@ -1,0 +1,141 @@
+/// Tool.swift
+///
+/// Copyright 2017-2018, The Silt Language Project.
+///
+/// This project is released under the MIT license, a copy of which is
+/// available in the repository.
+
+import SPMLibc
+import Basic
+import enum POSIX.SystemError
+import Utility
+
+public class SiltToolOptions {
+  let verbosity: Int = Verbosity.concise.rawValue
+  public required init() {}
+}
+
+public class SiltTool<Options: SiltToolOptions> {
+  /// The options of this tool.
+  let options: Options
+
+  /// Reference to the argument parser.
+  let parser: ArgumentParser
+
+  /// The process set to hold the launched processes. These will be terminated
+  /// on any signal received by the swift tools.
+  let processSet: ProcessSet
+
+  /// The interrupt handler.
+  let interruptHandler: InterruptHandler
+
+  /// The execution status of the tool.
+  var executionStatus: ExecutionStatus = .success
+
+  /// The stream to print standard output on.
+  fileprivate var stdoutStream: OutputByteStream = Basic.stdoutStream
+
+  /// If true, Redirects the stdout stream to stderr when invoking
+  /// `swift-build-tool`.
+  private var shouldRedirectStdoutToStderr = false
+
+  /// Create an instance of this tool.
+  ///
+  /// - parameter args: The command line arguments to be passed to this tool.
+  public init(toolName: String, usage: String, overview: String, args: [String],
+              seeAlso: String? = nil) {
+    // Create the parser.
+    self.parser = ArgumentParser(
+      commandName: "silt \(toolName)",
+      usage: usage,
+      overview: overview,
+      seeAlso: seeAlso)
+
+    // Create the binder.
+    let binder = ArgumentBinder<Options>()
+
+    // Let subclasses bind arguments.
+    type(of: self).defineArguments(parser: parser, binder: binder)
+
+    do {
+      // Parse the result.
+      let result = try parser.parse(args)
+
+      var options = Options()
+      binder.fill(result, into: &options)
+
+      self.options = options
+
+      let processSet = ProcessSet()
+      interruptHandler = try InterruptHandler {
+        // Terminate all processes on receiving an interrupt signal.
+        processSet.terminate()
+
+        // Install the default signal handler.
+        var action = sigaction()
+        #if os(macOS)
+        action.__sigaction_u.__sa_handler = SIG_DFL
+        #else
+        action.__sigaction_handler = unsafeBitCast(
+          SIG_DFL,
+          to: sigaction.__Unnamed_union___sigaction_handler.self)
+        #endif
+        sigaction(SIGINT, &action, nil)
+
+        // Die with sigint.
+        kill(getpid(), SIGINT)
+      }
+      self.processSet = processSet
+
+    } catch {
+      SiltTool.exit(with: .failure)
+    }
+  }
+
+  class func defineArguments(parser: ArgumentParser,
+                             binder: ArgumentBinder<Options>) {
+    fatalError("Must be implemented by subclasses")
+  }
+
+  /// Execute the tool.
+  public func run() {
+    do {
+      // Setup the globals.
+      verbosity = Verbosity(rawValue: options.verbosity)
+      Process.verbose = verbosity != .concise
+      // Call the implementation.
+      try runImpl()
+    } catch {
+      // Set execution status to failure in case of errors.
+      executionStatus = .failure
+    }
+    SiltTool.exit(with: executionStatus)
+  }
+
+  /// Exit the tool with the given execution status.
+  private static func exit(with status: ExecutionStatus) -> Never {
+    switch status {
+    case .success:
+      Darwin.exit(0)
+    case .failure:
+      Darwin.exit(1)
+    }
+  }
+
+  /// Run method implementation to be overridden by subclasses.
+  func runImpl() throws {
+    fatalError("Must be implemented by subclasses")
+  }
+
+  /// Start redirecting the standard output stream to the standard error stream.
+  func redirectStdoutToStderr() {
+    self.shouldRedirectStdoutToStderr = true
+    self.stdoutStream = Basic.stderrStream
+  }
+
+  /// An enum indicating the execution status of run commands.
+  enum ExecutionStatus {
+    case success
+    case failure
+  }
+}

--- a/Sources/Drill/Options.swift
+++ b/Sources/Drill/Options.swift
@@ -73,5 +73,18 @@ public class Options {
   public var inputURLs: [URL] = []
   public var typeCheckerDebugOptions: TypeCheckerDebugOptions = []
 
-  public init() {}
+  // FIXME: There is duplication here between the layers.
+  public init(
+    mode: Mode = .compile,
+    colorsEnabled: Bool = false,
+    shouldPrintTiming: Bool = false,
+    inputURLs: [URL],
+    typeCheckerDebugOptions: TypeCheckerDebugOptions
+  ) {
+    self.mode = mode
+    self.colorsEnabled = colorsEnabled
+    self.shouldPrintTiming = shouldPrintTiming
+    self.inputURLs = inputURLs
+    self.typeCheckerDebugOptions = typeCheckerDebugOptions
+  }
 }

--- a/Sources/Drill/StandardPasses.swift
+++ b/Sources/Drill/StandardPasses.swift
@@ -17,9 +17,11 @@ import OuterCore
 import InnerCore
 
 private func processImportedFile(_ modPath: URL) -> LocalNames? {
-  let options = Options()
-  options.mode = .dump(.typecheck)
-  options.inputURLs = [modPath]
+  let options = Options(mode: .dump(.typecheck),
+                        colorsEnabled: false,
+                        shouldPrintTiming: false,
+                        inputURLs: [modPath],
+                        typeCheckerDebugOptions: [])
   let context = PassContext(options: options)
   let result = Passes.scopeCheckAsImport.run(modPath, in: context)
   guard let (declModule, locals) = result else {

--- a/Sources/Lithosphere/DiagnosticEngine.swift
+++ b/Sources/Lithosphere/DiagnosticEngine.swift
@@ -25,7 +25,7 @@ public final class DiagnosticEngine {
   private var activeTransaction: Int?
 
   /// The set of consumers receiving diagnostic notifications from this engine.
-  private(set) private var consumers = [UUID: DiagnosticConsumer]()
+  private var consumers = [UUID: DiagnosticConsumer]()
 
   /// The next available (unique) transaction ID.
   private var transactionIDPool: Int = .min

--- a/Sources/Lithosphere/Trivia.swift
+++ b/Sources/Lithosphere/Trivia.swift
@@ -73,7 +73,7 @@ extension TriviaPiece {
 /// A collection of leading or trailing trivia. This is the main data structure
 /// for thinking about trivia.
 public struct Trivia {
-  internal(set) var pieces: [TriviaPiece]
+  var pieces: [TriviaPiece]
 
   /// Creates Trivia with the provided underlying pieces.
   public init(pieces: [TriviaPiece]) {

--- a/Sources/Seismography/TypeConverter.swift
+++ b/Sources/Seismography/TypeConverter.swift
@@ -171,6 +171,7 @@ public final class TypeConverter {
       }
     case .equal(_, _, _): fatalError()
     case .lambda(_): fatalError()
+    case .pi(_, _): fatalError()
     }
   }
 
@@ -241,6 +242,8 @@ extension TypeConverter {
       fatalError("FIXME: Emit metadata here")
     case .lambda(_):
       fatalError("FIXME: Emit metadata here")
+    case .pi(_, _):
+      fatalError()
     }
   }
 

--- a/Sources/lite/main.swift
+++ b/Sources/lite/main.swift
@@ -63,10 +63,10 @@ func run() -> Int32 {
     return EXIT_FAILURE
   }
 
-  var substitutions = [("silt", "\"\(url.path)\"")]
+  var substitutions = [("silt", "\(url.path)")]
 
   if let filecheckURL = findFileCheckExecutable() {
-    substitutions.append(("FileCheck", "\"\(filecheckURL.path)\""))
+    substitutions.append(("FileCheck", "\(filecheckURL.path)"))
   }
 
   let isParallel = !(result.get(runSerial) ?? false)


### PR DESCRIPTION
### What's in this pull request?

Redoes the layering between the Drill and Boring.  Boring is now the
primary way to interact with silt tooling and will eventually become the driver.

Begin by defining SiltFrontendTool which creates and executes a single
frontend invocation.  In the future, this should be a more general
SiltDriverTool that spawns multiple concurrent frontend invocations.
