### PR TITLE
Turn On Higher-Order Applies

### DIFF
--- a/Sources/Mantle/Check.swift
+++ b/Sources/Mantle/Check.swift
@@ -425,13 +425,13 @@ extension TypeChecker where PhaseState == CheckPhaseState {
       switch synPat {
       case let .variable(name):
         // FIXME: These indices are backwards.  We can undo this mistake in
-        // GIRGen, but that's lesss than ideal.
+        // GIRGen, but that's less than ideal.
         let ttVar = Var(name, UInt(self.environment.asContext.count))
         self.extendEnvironment([(name, patType)])
         return (.variable(ttVar), type)
       case .wild:
         // FIXME: These indices are backwards.  We can undo this mistake in
-        // GIRGen, but that's lesss than ideal.
+        // GIRGen, but that's less than ideal.
         let ttVar = Var(wildcardName, UInt(self.environment.asContext.count))
         self.extendEnvironment([(wildcardName, patType)])
         return (.variable(ttVar), type)
@@ -520,6 +520,14 @@ extension TypeChecker where PhaseState == CheckPhaseState {
           let innerPatType = self.rollPi(in: telescope, final: substType)
           // And check the inner patterns against it.
           let (pats, retTy) = self.checkPatterns(synPats, innerPatType)
+          if pats.isEmpty {
+            // If there are no patterns, bind a dummy into scope to keep
+            // the indices consistent.
+            //
+            // FIXME: These indices are backwards.  We can undo this mistake in
+            // GIRGen, but that's less than ideal.
+            self.extendEnvironment([(wildcardName, retTy)])
+          }
           return (.constructor(openDataCon, pats), retTy)
         case .apply(.definition(_), _):
           // FIXME: Should be a diagnostic.

--- a/Sources/Mantle/Normalize.swift
+++ b/Sources/Mantle/Normalize.swift
@@ -92,8 +92,15 @@ extension TypeChecker {
     }
   }
 
-  /// Reduces a TT term to head normal form, and produces a representation of
-  /// any new problems encountered during the reduction.
+  /// Reduces a TT term to weak head normal form.
+  ///
+  /// This function ignores any problems encountered during the reduction.
+  public func forceWHNF(_ t: TT) -> TT {
+    return self.toWeakHeadNormalForm(t).ignoreBlocking
+  }
+
+  /// Reduces a TT term to weak head normal form, and produces a representation
+  /// of any new problems encountered during the reduction.
   ///
   /// A term is in weak head-normal form when it is
   ///   - An unapplied lambda

--- a/Sources/Mantle/Support.swift
+++ b/Sources/Mantle/Support.swift
@@ -49,7 +49,7 @@ public struct Named<I: Hashable>: Equatable, Hashable, CustomStringConvertible {
   }
 
   public var description: String {
-    return self.name.description + "\(self.index.hashValue)"
+    return self.name.description + "\(self.index)"
   }
 }
 
@@ -555,6 +555,7 @@ public struct Clause {
       return self
     }
     var pats = self.patterns
+    pats.remove(at: column)
     pats.append(contentsOf: patterns)
     return Clause(patterns: pats, body: self.body)
   }

--- a/Tests/Mesosphere/Partial.silt
+++ b/Tests/Mesosphere/Partial.silt
@@ -1,0 +1,14 @@
+module Partial where
+
+data Nat : Type where
+  z : Nat
+  s : Nat -> Nat
+
+up : Nat -> Nat
+up = \ x -> s x
+
+ap : (Nat -> Nat) -> Nat
+ap f = f z
+
+ap2 : (Nat -> Nat) -> (Nat -> Nat) -> Nat
+ap2 f g = f (g z)


### PR DESCRIPTION
### What's in this pull request?

While fixing up the scoping of local declarations in the type checker, I noticed that we were creating de-Bruijn variables for patterns backwards.  We didn't notice this because we were doing a much more sinful hack in GIRGen called "looking at the names of variables in a locally nameless representation like dummies".  Switch GIRGen to use de-Bruijn indices and teach it to reverse the mistake that the type checker makes here.

This patch also enables higher-order applies by correctly λ-lifting (I'm not sure if this counts as lifting  if we're just doing it to the outer part of the pattern row's body?) clauses that are headed by lambdas.